### PR TITLE
MSON Namespace origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Refract is a a recursive data structure for expressing complex structures, relat
 
 - [Full Specification](refract-spec.md)
 - [JSON Namespace](namespaces/json-namespace.md)
+- [MSON Namespace](namespaces/mson-namespace.md)
 
 ## Version
 

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -235,6 +235,9 @@ The MSON Element adds attributes representing MSON _Type Definition_ and _Type S
 ## Object Type (JSON:Object Type)
 
 - Include MSON Element
+- `content` (array, required)
+    - (JSON:Property Type)
+    - (Select)
 
 ## Property Type (JSON:Property Type)
 

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -11,13 +11,13 @@ This namespace defines following elements:
     1. [Option](#option-distinct-element)
 
 1. MSON DOM-specific elements
-    1. [MSON Element](#mson-element-distinct-element)
-    1. [Boolean Type](#boolean-type-jsonboolean-type)
-    1. [String Type](#string-type-jsonstring-type)
-    1. [Number Type](#number-type-jsonnumber-type)
-    1. [Array Type](#array-type-jsonarray-type)
-    1. [Object Type](#object-type-jsonobject-type)
-    1. [Property Type](#property-type-jsonproperty-type)
+    1. [MSON Element](#mson-element-element)
+    1. [Boolean Type](#boolean-type-boolean-type)
+    1. [String Type](#string-type-string-type)
+    1. [Number Type](#number-type-number-type)
+    1. [Array Type](#array-type-array-type)
+    1. [Object Type](#object-type-object-type)
+    1. [Property Type](#property-type-property-type)
     1. [Enum Type](#enum-type-mson-element)
 
 # About this Document
@@ -42,7 +42,7 @@ The expanded DOM MUST, however, keep the track of what data structure was expand
 
 In MSON, every data structure is a sub-type of another data structure, and, therefore, it is directly or indirectly derived from one of the MSON _Base Types_. This is expressed as an inheritance of elements in MSON DOM. Where the predecessor of an element is referred to as element's _Base Element_.
 
-Note: Not every MSON _Base Type_ is presented in JSON namespace primitive types and vice versa, see the table bellow:
+Note: Not every MSON _Base Type_ is presented in Refract primitive types and vice versa – see the table bellow.
 
 ### Type comparison
 
@@ -63,23 +63,14 @@ General purpose elements defined inside MSON namespaces but possibly reusable in
 
 ## Select (Element)
 
-Element representing selection of options. Every item of content array represents one possible option.
+Element representing selection of options. Every Element of content array represents one possible option.
+
+The `select` element provides a way to inherit one or more mutually exclusive elements to form a new element. The `select` element MUST NOT affect the original elements being selected, and MUST define a new instance of an element.
 
 ### Properties
 
 - `element`: select (string, fixed)
-- `content` (array[Option])
-
-## Option (Element)
-
-One choice in the selection.
-
-### Properties
-
-- `element`: option (string fixed)
-- `content` (enum)
-    - (Element)
-    - (array[Element])
+- `content` (array[Element])
 
 ### Examples
 
@@ -95,22 +86,12 @@ One choice in the selection.
     "element": "select",
     "content": [
         {
-            "element": "option",
-            "content": [
-                {
-                    "element": "string",
-                    "content": "volvo"
-                }
-            ]
-        }
+            "element": "string",
+            "content": "Volvo"
+        },
         {
-            "element": "option",
-            "content": [
-                {
-                    "element": "string",
-                    "content": "Saab"
-                }
-            ]
+            "element": "string",
+            "content": "Saab"
         }
     ]
 }
@@ -161,9 +142,6 @@ Note: In MSON DOM _Nested Member Types_ _Type Section_ is the `content` of the e
 ## Object Type (Object Element)
 
 - Include [MSON Element][]
-- `content` (array, required)
-    - (Property Element)
-    - (Select)
 
 ## Property Type (Property Element)
 
@@ -176,7 +154,7 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
 ### Properties
 
 - `element`: enum (string, fixed)
-- `content` (array[MSON Element])
+- `content` (array[[MSON Element][]])
 
 ### Examples
 
@@ -231,19 +209,22 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
 
 ```json
 {
-    "element": "object",
-    "content": [
-        {
-            "element": "property",
-            "attributes": {
-                "name": "id"
-            },
-            "content": {
-                "element": "string",
-                "content": "42"
+    "element": "type",
+    "content": {
+        "element": "object",
+        "content": [
+            {
+                "element": "property",
+                "attributes": {
+                    "name": "id"
+                },
+                "content": {
+                    "element": "string",
+                    "content": "42"
+                }
             }
-        }
-    ]
+        ]
+    }
 }
 ```
 
@@ -259,20 +240,23 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
 
 ```json
 {
-    "element": "object",
-    "content": [
-        {
-            "element": "property",
-            "attributes": {
-                "name": "id",
-                "typeAttributes": ["required", "fixed"]
-            },
-            "content": {
-                "element": "string",
-                "content": "42"
+    "element": "type",
+    "content": {
+        "element": "object",
+        "content": [
+            {
+                "element": "property",
+                "attributes": {
+                    "name": "id",
+                    "typeAttributes": ["required", "fixed"]
+                },
+                "content": {
+                    "element": "string",
+                    "content": "42"
+                }
             }
-        }
-    ]
+        ]
+    }
 }
 ```
 
@@ -289,23 +273,26 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
 
 ```json
 {
+    "element": "type",
+    "content": {
     "element": "object",
-    "content": [
-        {
-            "element": "property",
-            "attributes": {
-                "name": "id",
-                "default": {
+        "content": [
+            {
+                "element": "property",
+                "attributes": {
+                    "name": "id",
+                    "default": {
+                        "element": "number",
+                        "content": 0
+                    }
+                },
+                "content": {
                     "element": "number",
-                    "content": 0
+                    "content": null
                 }
-            },
-            "content": {
-                "element": "number",
-                "content": null
             }
-        }
-    ]
+        ]
+    }
 }
 ```
 
@@ -322,44 +309,39 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
 
 #### MSON DOM
 
+TODO:
+
 ```json
 {
-    "element": "object",
-    "content": [
-        {
-            "element": "property",
-            "attributes": {
-                "name": "city"
-            }
-        },
-        {
-            "element": "select",
-            "content": [
-                {
-                    "element": "option",
-                    "content": [
-                        {
-                            "element": "property",
-                            "attributes": {
-                                "name": "state"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "element": "option",
-                    "content": [
-                        {
-                            "element": "property",
-                            "attributes": {
-                                "name": "province"
-                            }
-                        }
-                    ]
+    "element": "type",
+    "content": {
+        "element": "object",
+        "content": [
+            {
+                "element": "property",
+                "attributes": {
+                    "name": "city"
                 }
-            ]
-        }
-    ]
+            },
+            {
+                "element": "select",
+                "content": [
+                    {
+                        "element": "property",
+                        "attributes": {
+                            "name": "state"
+                        }
+                    },
+                    {
+                        "element": "property",
+                        "attributes": {
+                            "name": "province"
+                        }
+                    }
+                ]
+            }
+        ]
+    }
 }
 ```
 
@@ -376,42 +358,27 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
 
 ```json
 {
-    "element": "object",
-    "content": [
-        {
-            "element": "property",
-            "attributes": {
-                "name": "id"
+    "element": "type",
+    "content": {
+        "element": "extend",
+        "content": [
+            {
+                "element": "object",
+                "content": [
+                    {
+                        "element": "property",
+                        "attributes": {
+                            "name": "id"
+                        }
+                    }
+                ]
             }
-        }
-        {
-            "element": "ref",
-            "content": "#User"
-        }
-    ]
-}
-```
-
-**versus new refract?**
-
-```json
-{
-    "element": "object",
-    "content": [
-        {
-            "element": "property",
-            "attributes": {
-                "name": "id"
-            }
-        }
-        {
-            "element": "extend",
-            "content": {
+            {
                 "element": "ref",
                 "content": "#User"
             }
-        }
-    ]
+        ]
+    }
 }
 ```
 
@@ -433,34 +400,120 @@ Description is here! Properties to follow.
 
 ```json
 {
-    "element": "object",
-    "attributes": {
-        "id": "Address",
-        "description": "Description is here! Properties to follow."
-    },
-    "content": [
-        {
-            "element": "property",
-            "attributes": {
-                "name": "street"
+    "element": "type",
+    "content": {
+        "element": "object",
+        "attributes": {
+            "id": "Address",
+            "title": "Address",
+            "description": "Description is here! Properties to follow."
+        },
+        "content": [
+            {
+                "element": "property",
+                "attributes": {
+                    "name": "street"
+                }
             }
-        }
-    ]
+        ]
+    }
 }
 ```
 
-**versus new refract?**
+### Referencing & Expansion
+
+```markdown
+# User (object)
+- name
+
+# Customer (User)
+- id
+```
 
 ```json
 {
-    "element": "type"
-    bah how do I inherit from object and yet add properties? 
+    "element": "type",
+    "attributes": {
+        "id": "User"
+    },
+    "content": {
+        "element": "object",
+        "content": [
+            {
+                "element": "property",
+                "attributes": {
+                    "name": "name"
+                }
+            }
+        ]
+    }
 }
 ```
 
+```json
+{
+    "element": "type",
+    "attributes": {
+        "id": "Customer"
+    },
+    "content": {
+        "element": "User",
+        "content": [
+            {
+                "element": "property",
+                "attributes": {
+                    "name": "id"
+                }
+            }
+        ]
+    }
+}
+```
+
+#### Expanded
+
+```json
+{
+    "element": "type",
+    "attributes": {
+        "id": "Customer"
+    },
+    "content": {
+        "element": "extend",
+        "content": [
+            {
+                "element": "object",
+                "attributes": {
+                    "ref": "#User"
+                },
+                "content": [
+                    {
+                        "element": "property",
+                        "attributes": {
+                            "name": "name"
+                        }
+                    }
+                ]
+            },
+            {
+                "element": "object",
+                "content": [
+                    {
+                        "element": "property",
+                        "attributes": {
+                            "name": "id"
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
 
 
 [Refract]: https://github.com/refractproject/refract-spec/blob/master/refract-spec.md
 [JSON Namespace]: https://github.com/refractproject/refract-spec/blob/master/namespaces/json-namespace.md
 [MSON]: https://github.com/apiaryio/mson
 [MSON Specification]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md
+[MSON Element]: #mson-element-element

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -1,0 +1,119 @@
+# MSON Namespace
+
+This document extends [Refract][]'s [JSON Namespace][] with elements necessary to
+build [MSON][] DOM.
+
+# Terminology
+
+## Expanded Element
+
+MSON is built around the idea of defining recursive data structures. To provide abstraction, for convenience reasons and to not repeat ourselves these structures can be named and reused. In MSON, the reusable data structures are called _Named Types_.
+
+Often, before an MSON DOM can be processed referenced _Named Types_ have to be resolved. Resolving references to _Named Types_ is tedious and error prone. As such parser can resolve references and produce a complete MSON DOM, that is a DOM that does not include unresolved references to other data structures. This is referred to as _reference expansion_ or simply _expansion_.
+
+In other words, an expanded element is such an element that does not contain _Identifier_ (defined bellow) to any other elements but those defined in JSON or MSON namespaces.
+
+The expanded DOM MUST, however, keeps the track of what data structure was expanded and what from where.
+
+## Base Element
+
+In MSON, every data structure is a sub-type of another data structure, and, in transition, it is directly or indirectly derived from one of the MSON _Base Types_. This is expressed as an inheritance of elements in MSON DOM. Where the predecessor of an element is referred to as element's _Base Element_.
+
+Note not every MSON _Base Type_ is presented in JSON namespace primitive types and vice versa, see the table bellow:
+
+### JSON Namespace vs. MSON built-in types
+
+| JSON Namespace |   MSON  |
+|:--------------:|:-------:|
+|     boolean    | boolean |
+|     string     |  string |
+|     number     |  number |
+|      array     |  array  |
+|     &nbsp;     |   enum  |
+|     object     |  object |
+|      null      |  &nbsp; |
+
+# MSON DOM Elements Definition
+
+## Identifier (Enum)
+
+Identifier of an element in MSON DOM.
+
+### Members
+
+- (string)
+- (Distinct Element)
+    - `element`: id
+    - `content`: (string)
+
+## Distinct Element (Element)
+
+Abstract element representing an element that can be referenced or is a reference to another element.
+
+### Properties
+
+- `element` (Identifier, required) - identifier of this element's base element
+
+
+- `attributes`
+    - `id` (Identifier) - identifier of this element
+    - `ref` (Identifier) - reference to expanded element
+
+
+### Example
+
+```json
+{
+    "element": "number",
+    "attributes": {
+        "id": "my-number"
+    },
+    "content": 42
+}
+```
+
+which is identical to:
+
+```json
+{
+    "element": {
+        "element": "id",
+        "content": "number"
+    },
+    "attributes": {
+        "id": "my-number"
+    },
+    "content": 42
+}
+```
+
+and can be referred to as a _base element_:
+
+```json
+{
+    "element": "my-number"
+}
+```
+
+which _expands_ to:
+
+```json
+{
+    "element": "number",
+    "attributes": {
+        "ref": "my-number"
+    },
+    "content": 42
+}
+```
+
+## Data Structure (Element)
+
+
+
+
+
+
+[Refract]: https://github.com/refractproject/refract-spec/blob/master/refract-spec.md
+[JSON Namespace]: https://github.com/refractproject/refract-spec/blob/master/namespaces/json-namespace.md
+[MSON]: https://github.com/apiaryio/mson

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -1,15 +1,12 @@
 # MSON Namespace
 
-This document extends [Refract][]'s [JSON Namespace][] with elements necessary to
-build [MSON][] DOM.
+This document extends [Refract][] Specification with new element types necessary to build [MSON][] DOM.
 
 # Content
 
 This namespace defines following elements:
 
-1. General-use elements
-    1. [Id Element](#id-element-distinct-element)
-    1. [Distinct Element](#distinct-element-element)
+1. General-purpose elements
     1. [Select](#select-distinct-element)
     1. [Option](#option-distinct-element)
 
@@ -23,17 +20,21 @@ This namespace defines following elements:
     1. [Property Type](#property-type-jsonproperty-type)
     1. [Enum Type](#enum-type-mson-element)
 
-# Terminology
+# About this Document
 
-This specification uses terminology from [MSON Specification][]. In addition, the terms defined in this namespace are described below.
+This document conforms to RFC 2119, which says:
+
+> The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+
+[MSON][] is used throughout this document.
 
 ## Expanded Element
 
 MSON is built around the idea of defining recursive data structures. To provide abstraction, for convenience reasons and to not repeat ourselves, these structures can be named (using an _identifier_) and reused. In [MSON][], the reusable data structures are called _Named Types_.
 
-Often, before an MSON DOM can be processed referenced _Named Types_ have to be resolved. Resolving references to _Named Types_ is tedious and error prone. As such parser can resolve references and produce a complete MSON DOM, that is a DOM that does not include unresolved references to other data structures. This is referred to as _reference expansion_ or simply _expansion_.
+Often, before an MSON DOM can be processed, referenced _Named Types_ have to be resolved. Resolving references to _Named Types_ is tedious and error prone. As such an MSON processor can resolve references to produce a complete MSON DOM. That is, a DOM that does not include unresolved references to other data structures. This is referred to as _reference expansion_ or simply _expansion_.
 
-In other words, an expanded element  is one that does not contain any _Identifier_ (defined bellow) referencing any other elements than those defined in JSON or MSON namespaces.
+In other words, an expanded element is one that does not contain any _Identifier_ (defined bellow) referencing any other elements than those defined in JSON or MSON namespaces.
 
 The expanded DOM MUST, however, keep the track of what data structure was expanded and what from where.
 
@@ -43,121 +44,44 @@ In MSON, every data structure is a sub-type of another data structure, and, ther
 
 Note: Not every MSON _Base Type_ is presented in JSON namespace primitive types and vice versa, see the table bellow:
 
-### JSON Namespace vs. MSON built-in types
+### Type comparison
 
-| JSON primitive |   JSON Namespace   | MSON Base Type |   MSON Namespace   |
-|:--------------:|:------------------:|:--------------:|:------------------:|
-|     boolean    |  JSON:Boolean Type |     boolean    |  MSON:Boolean Type |
-|     string     |  JSON:String Type  |     string     |  MSON:String Type  |
-|     number     |  JSON:Number Type  |     number     |  MSON:Number Type  |
-|      array     |   JSON:Array Type  |      array     |   MSON:Array Type  |
-|        -       |          -         |      enum      |   MSON:Enum Type   |
-|     object     |  JSON:Object Type  |     object     |  MSON:Object Type  |
-|      null      |   JSON:Null Type   |        -       |          -         |
-|        -       | JSON:Property Type |        -       | MSON:Property Type |
+| JSON primitive |      Refract     | MSON Base Type | MSON Namespace |
+|:--------------:|:----------------:|:--------------:|:--------------:|
+|     boolean    |  Boolean Element |     boolean    |  Boolean Type  |
+|     string     |  String Element  |     string     |   String Type  |
+|     number     |  Number Element  |     number     |   Number Type  |
+|      array     |   Array Element  |      array     |   Array Type   |
+|        -       |         -        |      enum      |    Enum Type   |
+|     object     |  Object Element  |     object     |   Object Type  |
+|      null      |   Null Element   |        -       |        -       |
+|        -       | Property Element |        -       |  Property Type |
 
+# General Purpose Elements
 
-# General Elements Definition
+General purpose elements defined inside MSON namespaces but possibly reusable in another domain.
 
-General elements defined inside MSON namespaces but possibly reusable in another domain.
-
-## Identifier (Enum)
-
-Identifier of an element in the MSON namespace. The identifier MUST be either directly a `string` value or an `Id Element` element.
-
-### Members
-
-- (string)
-- (Id Element)
-
-## Id Element (Distinct Element)
-
-Element representing an identifier in the MSON namespace.
-
-### Properties
-
-- `element`: id (string, required, fixed)
-- `content` (string, required)
-
-## Distinct Element (Element)
-
-Abstract element representing an element that can be referenced or is a reference to another element.
-
-### Properties
-
-- `element` (Identifier, required) - identifier of this element's base element
-- `attributes`
-    - `id` (Identifier) - identifier of this element
-    - `ref` (Identifier) - reference to expanded element
-
-### Example
-
-```json
-{
-    "element": "number",
-    "attributes": {
-        "id": "my-number"
-    },
-    "content": 42
-}
-```
-
-which is identical to:
-
-```json
-{
-    "element": {
-        "element": "id",
-        "content": "number"
-    },
-    "attributes": {
-        "id": "my-number"
-    },
-    "content": 42
-}
-```
-
-and can be referred to as a _base element_:
-
-```json
-{
-    "element": "my-number"
-}
-```
-
-which _expands_ to:
-
-```json
-{
-    "element": "number",
-    "attributes": {
-        "ref": "my-number"
-    },
-    "content": 42
-}
-```
-
-## Select (Distinct Element)
+## Select (Element)
 
 Element representing selection of options. Every item of content array represents one possible option.
 
 ### Properties
 
-- `element`: select (string, required, fixed)
+- `element`: select (string, fixed)
 - `content` (array[Option])
 
-## Option (Distinct Element)
+## Option (Element)
 
 One choice in the selection.
 
 ### Properties
 
-- `element`: option (string, required, fixed)
+- `element`: option (string fixed)
 - `content` (enum)
-    - (Distinct Element)
-    - (array[Distinct Element])
+    - (Element)
+    - (array[Element])
 
-#### Example
+### Examples
 
 ```html
 <select>
@@ -192,13 +116,15 @@ One choice in the selection.
 }
 ```
 
-# MSON DOM Elements Definition
+# MSON DOM Elements
 
-## MSON Element (Distinct Element)
+## MSON Element (Element)
 
-Base element for all MSON elements.
+Base element for every MSON element.
 
-The MSON Element adds attributes representing MSON _Type Definition_ and _Type Sections_. Note in MSON DOM _Nested Member Types_ _Type Section_ is the `content` of the element.
+The MSON Element adds attributes representing MSON _Type Definition_ and _Type Sections_.
+
+Note: In MSON DOM _Nested Member Types_ _Type Section_ is the `content` of the element.
 
 ### Properties
 
@@ -211,37 +137,37 @@ The MSON Element adds attributes representing MSON _Type Definition_ and _Type S
             - sample
             - default
     - `variable` (boolean) - Element content is _Variable Value_
-    - `sample` (MSON Element) - Alternative sample _Member Types_ value
+    - `sample` (MSON Element) - Alternative sample value for _Member Types_
     - `default` (MSON Element) - Default value for _Member Types_
     - `validation` - Not used, reserved for a future use
     - `description` - Combined description of an MSON Element
 
-## Boolean Type (JSON:Boolean Type)
+## Boolean Type (Boolean Element)
 
-- Include MSON Element
+- Include [MSON Element][]
 
-## String Type (JSON:String Type)
+## String Type (String Element)
 
-- Include MSON Element
+- Include [MSON Element][]
 
-## Number Type (JSON:Number Type)
+## Number Type (Number Element)
 
-- Include MSON Element
+- Include [MSON Element][]
 
-## Array Type (JSON:Array Type)
+## Array Type (Array Element)
 
-- Include MSON Element
+- Include [MSON Element][]
 
-## Object Type (JSON:Object Type)
+## Object Type (Object Element)
 
-- Include MSON Element
+- Include [MSON Element][]
 - `content` (array, required)
-    - (JSON:Property Type)
+    - (Property Element)
     - (Select)
 
-## Property Type (JSON:Property Type)
+## Property Type (Property Element)
 
-- Include MSON Element
+- Include [MSON Element][]
 
 ## Enum Type (MSON Element)
 
@@ -249,10 +175,10 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
 
 ### Properties
 
-- `element`: enum (string, required, fixed)
+- `element`: enum (string, fixed)
 - `content` (array[MSON Element])
 
-### Example
+### Examples
 
 #### MSON
 
@@ -291,8 +217,6 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
 }
 ```
 
-
-
 ## Examples
 
 ### Anonymous Object Type
@@ -300,7 +224,7 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
 #### MSON
 
 ```
-- id: 1
+- id: 42
 ```
 
 #### MSON DOM
@@ -316,7 +240,7 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
             },
             "content": {
                 "element": "string",
-                "content": "1"
+                "content": "42"
             }
         }
     ]
@@ -461,7 +385,31 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
             }
         }
         {
-            "element": "User"
+            "element": "ref",
+            "content": "#User"
+        }
+    ]
+}
+```
+
+**versus new refract?**
+
+```json
+{
+    "element": "object",
+    "content": [
+        {
+            "element": "property",
+            "attributes": {
+                "name": "id"
+            }
+        }
+        {
+            "element": "extend",
+            "content": {
+                "element": "ref",
+                "content": "#User"
+            }
         }
     ]
 }
@@ -473,9 +421,11 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
 
 ```
 # Address (object)
+
 Description is here! Properties to follow.
 
 ## Properties
+
 - street
 ```
 
@@ -499,8 +449,18 @@ Description is here! Properties to follow.
 }
 ```
 
+**versus new refract?**
+
+```json
+{
+    "element": "type"
+    bah how do I inherit from object and yet add properties? 
+}
+```
+
+
+
 [Refract]: https://github.com/refractproject/refract-spec/blob/master/refract-spec.md
 [JSON Namespace]: https://github.com/refractproject/refract-spec/blob/master/namespaces/json-namespace.md
 [MSON]: https://github.com/apiaryio/mson
-
 [MSON Specification]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -53,8 +53,6 @@ Abstract element representing an element that can be referenced or is a referenc
 ### Properties
 
 - `element` (Identifier, required) - identifier of this element's base element
-
-
 - `attributes`
     - `id` (Identifier) - identifier of this element
     - `ref` (Identifier) - reference to expanded element
@@ -107,9 +105,129 @@ which _expands_ to:
 }
 ```
 
-## Data Structure (Element)
+## MSON Element (Distinct Element)
+
+- `attributes`
+    - `typeAttributes` (array[enum])
+        - required (string)
+        - fixed (string)
+        - variable (string)
+    - `sample`
+    - `default`
+    - `validation`
+    - `description`
 
 
+### Example
+
+#### MSON
+
+```
+- id: 1
+```
+
+#### MSON DOM
+
+```json
+{
+    "element": "object",
+    "content": [
+        {
+            "element": "property",
+            "attributes": {
+                "name": "id"
+            },
+            "content": {
+                "element": "string",
+                "content": "1"
+            }
+        }
+    ]
+}
+```
+
+
+#### MSON
+
+```
+- id: 42 (required, fixed)
+```
+
+#### MSON DOM
+
+```json
+{
+    "element": "object",
+    "content": [
+        {
+            "element": "property",
+            "attributes": {
+                "name": "id",
+                "typeAttributes": ["required", "fixed"]
+            },
+            "content": {
+                "element": "string",
+                "content": "42"
+            }
+        }
+    ]
+}
+```
+
+#### MSON
+
+```
+- id (number)
+    - default: 0
+```
+
+#### MSON DOM
+
+```json
+{
+    "element": "object",
+    "content": [
+        {
+            "element": "property",
+            "attributes": {
+                "name": "id",
+                "default": {
+                    "element": "number",
+                    "content": 0
+                }
+            },
+            "content": {
+                "element": "number",
+                "content": null
+            }
+        }
+    ]
+}
+```
+
+## Enum Type (MSON Element)
+
+- `element`: enum (string, required, fixed)
+- `content` (array[MSON Element])
+
+### Example
+
+#### MSON
+
+```
+TODO:
+```
+
+#### MSON DOM
+
+```json
+TODO:
+```
+
+TODO:
+- one of
+- mixin
+- named type example
 
 
 

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -3,7 +3,29 @@
 This document extends [Refract][]'s [JSON Namespace][] with elements necessary to
 build [MSON][] DOM.
 
+# Content
+
+This namespace defines following elements:
+
+1. General-use elements
+    1. [Id Element](#id-element-distinct-element)
+    1. [Distinct Element](#distinct-element-element)
+    1. [Select](#select-distinct-element)
+    1. [Option](#option-distinct-element)
+
+1. MSON DOM-specific elements
+    1. [MSON Element](#mson-element-distinct-element)
+    1. [Boolean Type](#boolean-type-jsonboolean-type)
+    1. [String Type](#string-type-jsonstring-type)
+    1. [Number Type](#number-type-jsonnumber-type)
+    1. [Array Type](#array-type-jsonarray-type)
+    1. [Object Type](#object-type-jsonobject-type)
+    1. [Property Type](#property-type-jsonproperty-type)
+    1. [Enum Type](#enum-type-mson-element)
+
 # Terminology
+
+This specification uses terminology from [MSON Specification][], in addition, bellow you can find the explanation of terms defined in this namespace.
 
 ## Expanded Element
 
@@ -125,6 +147,8 @@ Element representing selection of options. Every item of content array represent
 - `content` (array[Option])
 
 ## Option (Distinct Element)
+
+One choice in the selection.
 
 ### Properties
 
@@ -475,3 +499,5 @@ Description is here! Properties to follow.
 [Refract]: https://github.com/refractproject/refract-spec/blob/master/refract-spec.md
 [JSON Namespace]: https://github.com/refractproject/refract-spec/blob/master/namespaces/json-namespace.md
 [MSON]: https://github.com/apiaryio/mson
+
+[MSON Specification]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -25,23 +25,23 @@ This namespace defines following elements:
 
 # Terminology
 
-This specification uses terminology from [MSON Specification][], in addition, bellow you can find the explanation of terms defined in this namespace.
+This specification uses terminology from [MSON Specification][]. In addition, the terms defined in this namespace are described below.
 
 ## Expanded Element
 
-MSON is built around the idea of defining recursive data structures. To provide abstraction, for convenience reasons and to not repeat ourselves these structures can be named (using an _identifier_) and reused. In MSON, the reusable data structures are called _Named Types_.
+MSON is built around the idea of defining recursive data structures. To provide abstraction, for convenience reasons and to not repeat ourselves, these structures can be named (using an _identifier_) and reused. In [MSON][], the reusable data structures are called _Named Types_.
 
 Often, before an MSON DOM can be processed referenced _Named Types_ have to be resolved. Resolving references to _Named Types_ is tedious and error prone. As such parser can resolve references and produce a complete MSON DOM, that is a DOM that does not include unresolved references to other data structures. This is referred to as _reference expansion_ or simply _expansion_.
 
-In other words, an expanded element is such an element that does not contain _Identifier_ (defined bellow) to any other elements but those defined in JSON or MSON namespaces.
+In other words, an expanded element  is one that does not contain any _Identifier_ (defined bellow) referencing any other elements than those defined in JSON or MSON namespaces.
 
-The expanded DOM MUST, however, keeps the track of what data structure was expanded and what from where.
+The expanded DOM MUST, however, keep the track of what data structure was expanded and what from where.
 
 ## Base Element
 
-In MSON, every data structure is a sub-type of another data structure, and, in transition, it is directly or indirectly derived from one of the MSON _Base Types_. This is expressed as an inheritance of elements in MSON DOM. Where the predecessor of an element is referred to as element's _Base Element_.
+In MSON, every data structure is a sub-type of another data structure, and, therefore, it is directly or indirectly derived from one of the MSON _Base Types_. This is expressed as an inheritance of elements in MSON DOM. Where the predecessor of an element is referred to as element's _Base Element_.
 
-Note not every MSON _Base Type_ is presented in JSON namespace primitive types and vice versa, see the table bellow:
+Note: Not every MSON _Base Type_ is presented in JSON namespace primitive types and vice versa, see the table bellow:
 
 ### JSON Namespace vs. MSON built-in types
 

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -379,7 +379,9 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
             "element": "property",
             "attributes": {
                 "name": "city"
-            },
+            }
+        },
+        {
             "element": "select",
             "content": [
                 {

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -215,13 +215,38 @@ which _expands_ to:
 #### MSON
 
 ```
-TODO:
+- tag (enum[string])
+    - red
+    - green
 ```
 
 #### MSON DOM
 
 ```json
-TODO:
+{
+    "element": "object",
+    "content": [
+        {
+            "element": "property",
+            "attributes": {
+                "name": "tag"
+            },
+            "content": {
+                "element": "enum",
+                "content": [
+                    {
+                        "element": "string",
+                        "content": "red"
+                    },
+                    {
+                        "element": "string",
+                        "content": "green"
+                    }
+                ]
+            }
+        }
+    ]
+}
 ```
 
 TODO:


### PR DESCRIPTION
This PR introduces MSON namespace – a minimal set of elements needed to replace existing [MSON AST](https://github.com/apiaryio/mson-ast) with the element-based MSON DOM. 

The Namespace is split into two parts: 
1. General used elements – elements that, in my opinion, may be used outside of the MSON domain
2. MSON DOM specific elements.

Please pay close attention to the `Distinct Element` as I believe this is the "future proof" element type concept that enables us to do referencing including namespaces. Note it is out of the scope of this specification to solve the namespaces of element identifiers. The `Distinct Element` element, however, is designed with future element identifier namespaces in mind. It should be possible to solve it by adding `namespace`, `prefix` and possibly `class` attributes to the `Distinct Element` attributes. I am open to discuss this as part of this PR, but it is not as important as providing SDKs based on this new MSON DOM structure.
