### PR TITLE
Introduce a Representor Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Refract is a a recursive data structure for expressing complex structures, relat
 
 - [Full Specification](refract-spec.md)
 - [MSON Namespace](namespaces/mson-namespace.md)
+- [Representor Namespace](namespaces/Representor.md)
 
 ## Version
 

--- a/namespaces/Representor.md
+++ b/namespaces/Representor.md
@@ -24,8 +24,8 @@ A transition is an available progression from one state to another state.
 - `element`: transition (string, fixed)
 - `attributes` (object, required)
     - `relation` - (string, required) - The relation of this transition from the current resource.
-    - `parameters` (array[Input Property]) - A collection of parameters for this transition.
-    - `attributes` (array[Input Property]) - A collection of possible attributes for this transition.
+    - `parameters` ([Object Type][]) - A collection of parameters for this transition.
+    - `attributes` ([Object Type][]) - A collection of possible attributes for this transition.
 - `content` (string, required) - The URI for this transition.
 
 ### Example
@@ -40,44 +40,5 @@ A transition is an available progression from one state to another state.
 }
 ```
 
-## Input Property
-
-An Input Property is used to describe a potential property or attribute used to perform a transition.
-
-### Properties
-
-- `element`: property (string, fixed)
-- `content`: (object)
-    - `name` (string, required) - The name for this property.
-    - `type` (string) - The type of element used to represent the properties value.
-    - `defaultValue` (Any Type) - An optional default value for this property.
-
-### Example
-
-```json
-{
-    "element": "property",
-    "content": [
-        {
-            "key": {
-                "element": "string",
-                "content": "name"
-            },
-            "value": {
-                "element": "string",
-                "content": "username"
-            }
-        }, {
-            "key": {
-                "element": "string",
-                "content": "type"
-            },
-            "value": {
-                "element": "string",
-                "content": "string"
-            }
-        }
-    ]
-}
-```
+[Object Type]: https://github.com/refractproject/refract-spec/blob/master/namespaces/mson-namespace.md#object-type-object-element
 

--- a/namespaces/Representor.md
+++ b/namespaces/Representor.md
@@ -2,26 +2,29 @@
 
 This document extends [Refract](../refract-spec.md) Specification to describe the [Representor](https://github.com/the-hypermedia-project/charter) DOM.
 
-## Representor (Object Element)
+## Resource (Object Element)
 
-The Representor represents a Hypermedia Resource, with it's available links, transitions and attributes.
-
-### Properties
-
-- `links` - (array[Link]) - The links from this resource.
-- `transitions` - (array[Transition]) - The available transitions from this resource.
-- `representors` - (array[Representor]) - The embedded links (resources) from this resource.
-- `attributes` - (object) - Any properties of the resource.
-- `metadata` - (object) _ Meta Attributes, for example, may include a `title` and `description`.
-
-## Link (Object Element)
-
-A link element representing a link and it's relation from the Representor.
+The Resource represents a Hypermedia Resource, with it's available relations, transitions and attributes.
 
 ### Properties
 
-- `relation` - (string, required) - The relation from the Representor to this link.
-- `uri` - (string, required) - The URI for this link.
+- `element`: resource (string, fixed)
+- `content`: (object)
+    - `relations` - (array[Relation]) - The relations from this resource.
+    - `transitions` - (array[Transition]) - The available transitions from this resource.
+    - `resources` - (array[Resource]) - The embedded relations (resources) from this resource.
+    - `attributes` - (object) - Any properties of the resource.
+
+## Relation (Object Element)
+
+A relation element representing a relation to another resource.
+
+### Properties
+
+- `element`: object (string, fixed)
+- `content`: (object)
+    - `relation` - (string, required) - The relation from the Resource to this resource.
+    - `uri` - (string, required) - The URI for this relation.
 
 ### Example
 
@@ -58,10 +61,12 @@ A transition is an available progression from one state to another state.
 
 ### Properties
 
-- `relation` - (string, required) - The relation of this transition from the current resource.
-- `uri` - (string, required) - The URI for this transition.
-- `parameters` (array[Input Property])
-- `attributes` (array[Input Property])
+- `element`: object (string, fixed)
+- `content`: (object)
+    - `relation` - (string, required) - The relation of this transition from the current resource.
+    - `uri` - (string, required) - The URI for this transition.
+    - `parameters` (array[Input Property])
+    - `attributes` (array[Input Property])
 
 ### Example
 
@@ -98,9 +103,11 @@ An Input Property is used to describe a potential property or attribute used to 
 
 ### Properties
 
-- `name` (string, required) - The name for this property.
-- `type` (string) - The type of element used to represent the properties value.
-- `defaultValue` (Any Type) - An optional default value for this property.
+- `element`: object (string, fixed)
+- `content`: (object)
+    - `name` (string, required) - The name for this property.
+    - `type` (string) - The type of element used to represent the properties value.
+    - `defaultValue` (Any Type) - An optional default value for this property.
 
 ### Example
 

--- a/namespaces/Representor.md
+++ b/namespaces/Representor.md
@@ -4,17 +4,17 @@ This document extends [Refract](../refract-spec.md) Specification to describe th
 
 ## Resource (Object Element)
 
-The Resource represents a Hypermedia Resource, with it's available relations, transitions and attributes.
+The Resource represents a Hypermedia Resource, with its available relations, transitions and attributes.
 
 ### Properties
 
 - `element`: resource (string, fixed)
-- `content`: (object)
+- `attributes` (object)
     - `relations` - (array[Relation]) - The relations from this resource.
     - `transitions` - (array[Transition]) - The available transitions from this resource.
     - `resources` - (array[Resource]) - The embedded relations (resources) from this resource.
-    - `attributes` - (object) - Any properties of the resource.
-    - `relation` - (string) - An optional relation to this resource.
+    - `relation` - (string) - An optional relation to this resource, when embedded in another resource.
+- `content` (object) - Any properties of the resource.
 
 ## Relation (Object Element)
 
@@ -23,36 +23,19 @@ A relation element representing a relation to another resource.
 ### Properties
 
 - `element`: relation (string, fixed)
-- `content`: (object)
+- `attributes` (object, required)
     - `relation` - (string, required) - The relation from the Resource to this resource.
-    - `uri` - (string, required) - The URI for this relation.
+- `content` (string, required) - The URI for this relation.
 
 ### Example
 
 ```json
 {
     "element": "relation",
-    "content": [
-        {
-            "key": {
-                "element": "string",
-                "content": "relation"
-            },
-            "value": {
-                "element": "string",
-                "content": "self"
-            }
-        }, {
-            "key": {
-                "element": "string",
-                "content": "uri"
-            },
-            "value": {
-                "element": "string",
-                "content": "https://polls.apiblueprint.org/questions/1"
-            }
-        }
-    ]
+    "attributes": {
+      "relation": "self"
+    },
+    "content": "https://polls.apiblueprint.org/questions/1"
 }
 ```
 
@@ -63,38 +46,21 @@ A transition is an available progression from one state to another state.
 ### Properties
 
 - `element`: transition (string, fixed)
-- `content`: (object)
+- `attributes` (object, required)
     - `relation` - (string, required) - The relation of this transition from the current resource.
-    - `uri` - (string, required) - The URI for this transition.
-    - `parameters` (array[Input Property])
-    - `attributes` (array[Input Property])
+    - `parameters` (array[Input Property]) - A collection of parameters for this transition.
+    - `attributes` (array[Input Property]) - A collection of possible attributes for this transition.
+- `content` (string, required) - The URI for this transition.
 
 ### Example
 
 ```json
 {
     "element": "transition",
-    "content": [
-        {
-            "key": {
-                "element": "string",
-                "content": "relation"
-            },
-            "value": {
-                "element": "string",
-                "content": "update"
-            }
-        }, {
-            "key": {
-                "element": "string",
-                "content": "uri"
-            },
-            "value": {
-                "element": "string",
-                "content": "https://polls.apiblueprint.org/questions/1"
-            }
-        }
-    ]
+    "attributes": {
+      "relation": "update"
+    },
+    "content": "https://polls.apiblueprint.org/questions/1"
 }
 ```
 

--- a/namespaces/Representor.md
+++ b/namespaces/Representor.md
@@ -8,11 +8,11 @@ The Representor represents a Hypermedia Resource, with it's available links, tra
 
 ### Properties
 
-- `links` - (Array Element of Link) - The links from this resource.
-- `transitions` - (Array Element of Transition) - The available transitions from this resource.
-- `representors` - (Array Element of Representor) - The embedded links (resources) from this resource.
-- `attributes` - (Object Element) - Any properties of the resource.
-- `metadata` - (Object Element) _ Meta Attributes, for example, may include a `title` and `description`.
+- `links` - (array[Link]) - The links from this resource.
+- `transitions` - (array[Transition]) - The available transitions from this resource.
+- `representors` - (array[Representor]) - The embedded links (resources) from this resource.
+- `attributes` - (object) - Any properties of the resource.
+- `metadata` - (object) _ Meta Attributes, for example, may include a `title` and `description`.
 
 ## Link (Object Element)
 
@@ -20,8 +20,8 @@ A link element representing a link and it's relation from the Representor.
 
 ### Properties
 
-- `relation` - (String Element, required) - The relation from the Representor to this link.
-- `uri` - (String Element, required) - The URI for this link.
+- `relation` - (string, required) - The relation from the Representor to this link.
+- `uri` - (string, required) - The URI for this link.
 
 ### Example
 
@@ -58,10 +58,10 @@ A transition is an available progression from one state to another state.
 
 ### Properties
 
-- `relation` - (String Element, required) - The relation of this transition from the current resource.
-- `uri` - (String Element, required) - The URI for this transition.
-- `parameters` (Array Element of Input Property)
-- `attributes` (Array Element of Input Property)
+- `relation` - (string, required) - The relation of this transition from the current resource.
+- `uri` - (string, required) - The URI for this transition.
+- `parameters` (array[Input Property])
+- `attributes` (array[Input Property])
 
 ### Example
 
@@ -98,8 +98,8 @@ An Input Property is used to describe a potential property or attribute used to 
 
 ### Properties
 
-- `name` (String Element, required) - The name for this property.
-- `type` (String Element) - The type of element used to represent the properties value.
+- `name` (string, required) - The name for this property.
+- `type` (string) - The type of element used to represent the properties value.
 - `defaultValue` (Any Type) - An optional default value for this property.
 
 ### Example

--- a/namespaces/Representor.md
+++ b/namespaces/Representor.md
@@ -1,0 +1,133 @@
+# Representor Namespace
+
+This document extends [Refract](../refract-spec.md) Specification to describe the [Representor](https://github.com/the-hypermedia-project/charter) DOM.
+
+## Representor (Object Element)
+
+The Representor represents a Hypermedia Resource, with it's available links, transitions and attributes.
+
+### Properties
+
+- `links` - (Array Element of Link) - The links from this resource.
+- `transitions` - (Array Element of Transition) - The available transitions from this resource.
+- `representors` - (Array Element of Representor) - The embedded links (resources) from this resource.
+- `attributes` - (Object Element) - Any properties of the resource.
+- `metadata` - (Object Element) _ Meta Attributes, for example, may include a `title` and `description`.
+
+## Link (Object Element)
+
+A link element representing a link and it's relation from the Representor.
+
+### Properties
+
+- `relation` - (String Element, required) - The relation from the Representor to this link.
+- `uri` - (String Element, required) - The URI for this link.
+
+### Example
+
+```json
+{
+    "element": "object",
+    "content": [
+        {
+            "key": {
+                "element": "string",
+                "content": "relation"
+            },
+            "value": {
+                "element": "string",
+                "content": "self"
+            }
+        }, {
+            "key": {
+                "element": "string",
+                "content": "uri"
+            },
+            "value": {
+                "element": "string",
+                "content": "https://polls.apiblueprint.org/questions/1"
+            }
+        }
+    ]
+}
+```
+
+## Transition (Object Element)
+
+A transition is an available progression from one state to another state.
+
+### Properties
+
+- `relation` - (String Element, required) - The relation of this transition from the current resource.
+- `uri` - (String Element, required) - The URI for this transition.
+- `parameters` (Array Element of Input Property)
+- `attributes` (Array Element of Input Property)
+
+### Example
+
+```json
+{
+    "element": "object",
+    "content": [
+        {
+            "key": {
+                "element": "string",
+                "content": "relation"
+            },
+            "value": {
+                "element": "string",
+                "content": "update"
+            }
+        }, {
+            "key": {
+                "element": "string",
+                "content": "uri"
+            },
+            "value": {
+                "element": "string",
+                "content": "https://polls.apiblueprint.org/questions/1"
+            }
+        }
+    ]
+}
+```
+
+## Input Property
+
+An Input Property is used to describe a potential property or attribute used to perform a transition.
+
+### Properties
+
+- `name` (String Element, required) - The name for this property.
+- `type` (String Element) - The type of element used to represent the properties value.
+- `defaultValue` (Any Type) - An optional default value for this property.
+
+### Example
+
+```json
+{
+    "element": "object",
+    "content": [
+        {
+            "key": {
+                "element": "string",
+                "content": "name"
+            },
+            "value": {
+                "element": "string",
+                "content": "username"
+            }
+        }, {
+            "key": {
+                "element": "string",
+                "content": "type"
+            },
+            "value": {
+                "element": "string",
+                "content": "string"
+            }
+        }
+    ]
+}
+```
+

--- a/namespaces/Representor.md
+++ b/namespaces/Representor.md
@@ -14,6 +14,7 @@ The Resource represents a Hypermedia Resource, with it's available relations, tr
     - `transitions` - (array[Transition]) - The available transitions from this resource.
     - `resources` - (array[Resource]) - The embedded relations (resources) from this resource.
     - `attributes` - (object) - Any properties of the resource.
+    - `relation` - (string) - An optional relation to this resource.
 
 ## Relation (Object Element)
 

--- a/namespaces/Representor.md
+++ b/namespaces/Representor.md
@@ -2,42 +2,18 @@
 
 This document extends [Refract](../refract-spec.md) Specification to describe the [Representor](https://github.com/the-hypermedia-project/charter) DOM.
 
-## Resource (Object Element)
+## Resource (Element)
 
-The Resource represents a Hypermedia Resource, with its available relations, transitions and attributes.
+The Resource represents a Hypermedia Resource, with its available transitions and attributes.
 
 ### Properties
 
 - `element`: resource (string, fixed)
 - `attributes` (object)
-    - `relations` - (array[Relation]) - The relations from this resource.
     - `transitions` - (array[Transition]) - The available transitions from this resource.
-    - `resources` - (array[Resource]) - The embedded relations (resources) from this resource.
-    - `relation` - (string) - An optional relation to this resource, when embedded in another resource.
+    - `resources` - (array[Resource]) - Any embedded (resources) from this resource.
+    - `relation` - (string) - An optional relation to this resource, applicable when embedded in another resource.
 - `content` (object) - Any properties of the resource.
-
-## Relation (Object Element)
-
-A relation element representing a relation to another resource.
-
-### Properties
-
-- `element`: relation (string, fixed)
-- `attributes` (object, required)
-    - `relation` - (string, required) - The relation from the Resource to this resource.
-- `content` (string, required) - The URI for this relation.
-
-### Example
-
-```json
-{
-    "element": "relation",
-    "attributes": {
-      "relation": "self"
-    },
-    "content": "https://polls.apiblueprint.org/questions/1"
-}
-```
 
 ## Transition (Object Element)
 

--- a/namespaces/Representor.md
+++ b/namespaces/Representor.md
@@ -26,6 +26,7 @@ A transition is an available progression from one state to another state.
     - `relation` - (string, required) - The relation of this transition from the current resource.
     - `parameters` ([Object Type][]) - A collection of parameters for this transition.
     - `attributes` ([Object Type][]) - A collection of possible attributes for this transition.
+    - `suggestedContentTypes` (array[string]) - A collection of suggested content types to encode the attributes, ordered by preference.
 - `content` (string, required) - The URI for this transition.
 
 ### Example

--- a/namespaces/Representor.md
+++ b/namespaces/Representor.md
@@ -21,7 +21,7 @@ A relation element representing a relation to another resource.
 
 ### Properties
 
-- `element`: object (string, fixed)
+- `element`: relation (string, fixed)
 - `content`: (object)
     - `relation` - (string, required) - The relation from the Resource to this resource.
     - `uri` - (string, required) - The URI for this relation.
@@ -30,7 +30,7 @@ A relation element representing a relation to another resource.
 
 ```json
 {
-    "element": "object",
+    "element": "relation",
     "content": [
         {
             "key": {
@@ -61,7 +61,7 @@ A transition is an available progression from one state to another state.
 
 ### Properties
 
-- `element`: object (string, fixed)
+- `element`: transition (string, fixed)
 - `content`: (object)
     - `relation` - (string, required) - The relation of this transition from the current resource.
     - `uri` - (string, required) - The URI for this transition.
@@ -72,7 +72,7 @@ A transition is an available progression from one state to another state.
 
 ```json
 {
-    "element": "object",
+    "element": "transition",
     "content": [
         {
             "key": {
@@ -103,7 +103,7 @@ An Input Property is used to describe a potential property or attribute used to 
 
 ### Properties
 
-- `element`: object (string, fixed)
+- `element`: property (string, fixed)
 - `content`: (object)
     - `name` (string, required) - The name for this property.
     - `type` (string) - The type of element used to represent the properties value.
@@ -113,7 +113,7 @@ An Input Property is used to describe a potential property or attribute used to 
 
 ```json
 {
-    "element": "object",
+    "element": "property",
     "content": [
         {
             "key": {


### PR DESCRIPTION
This pull request is a work in progress pull request to add a namespace for the Representor pattern as described in the [hypermedia charter](https://github.com/the-hypermedia-project/charter).

I'm not entirely sure this is what we're looking for. Can someone (@zdne?) take a look at point in in what direction I should be taking this.
