### PR TITLE
Fix transaction example

### DIFF
--- a/namespaces/resource-namespace.md
+++ b/namespaces/resource-namespace.md
@@ -223,19 +223,20 @@ message pair. A transaction example MUST contain exactly one HTTP request and on
         {
             "element": "httpResponse",
             "attributes": {
-                "status": 200,
-                "assets": [
-                    {
-                        "element": "asset",
-                        "meta": {
-                            "class": "messageBody"
-                        },
-                        "attributes": {},
-                        "content": "{\"name\": \"John\"}"
-                    }
-                ]
+                "status": 200
             },
-            "content": null
+            "content": [
+                {
+                    "element": "asset",
+                    "meta": {
+                        "class": "messageBody"
+                    },
+                    "attributes": {
+                      "contentType": "application/json"
+                    },
+                    "content": "{\"name\": \"John\"}"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Assets are part of the content rather than an attribute. This changes up that example and adds a contentType for the asset.

cc: @zdne 
