### PR TITLE
Fix resource namespace examples

### DIFF
--- a/namespaces/resource-namespace.md
+++ b/namespaces/resource-namespace.md
@@ -114,10 +114,14 @@ The Resource representation with its available transitions and attributes.
         "href": "/questions/{question_id}",
         "hrefVariables": {
             "element": "hrefVariables",
-            "attributes": {
-                "name": "question_id"
-            },
-            "content": null
+            "content": [
+              {
+                "element": "string",
+                "meta": {
+                  "name": "question_id"
+                }
+              }
+            ]
         }
     },
     "content": [
@@ -223,7 +227,7 @@ message pair. A transaction example MUST contain exactly one HTTP request and on
         {
             "element": "httpResponse",
             "attributes": {
-                "status": 200
+                "statusCode": 200
             },
             "content": [
                 {


### PR DESCRIPTION
This fixes two examples. The first changes how `hrefVariables` is
handled. It is an Object, so content needs an array of elements with
`meta.name` attributes.

The second fixes a typo with the status code.
