### PR TITLE
Attributes metadata

### DIFF
--- a/namespaces/api-namespace.md
+++ b/namespaces/api-namespace.md
@@ -42,6 +42,11 @@ For example a `category` element may be classified both as `resourceGroup` and
             - resourceGroup - Category is a set of resource.
             - dataStructures - Category is a set of data structures.
             - scenario - Reserved. Category is set of steps.
+- `attributes`
+    - `meta` (object) - Arbitrary metadata
+        - `user` (array[String Pair]) - User-specific metadata. Metadata written in the source.
+        - `adapter` (array[String Pair]) - Serialization-specific metadata. Metadata provided by adapter.
+
 - `content` (array[Element])
 
 ### Example
@@ -54,6 +59,16 @@ For example a `category` element may be classified both as `resourceGroup` and
             "api"
         ],
         "title": "Polls API"
+    },
+    "attributes": {
+        "meta": {
+            "user": [
+                {
+                    "key":  "HOST",
+                    "value": "http://polls.apiblueprint.org/"
+                }
+            ]
+        }
     },
     "content": [
         {
@@ -124,6 +139,15 @@ Given an API description with following layout:
     ]
 }
 ```
+
+## String Pair (object)
+
+Key-value pair where both key and value are of a string type.
+
+### Properties
+
+- `key` (string, required) - Key for the metadata
+- `value` (string, optional) - Value for the metadata
 
 ---
 

--- a/namespaces/api-namespace.md
+++ b/namespaces/api-namespace.md
@@ -43,9 +43,13 @@ For example a `category` element may be classified both as `resourceGroup` and
             - dataStructures - Category is a set of data structures.
             - scenario - Reserved. Category is set of steps.
 - `attributes`
-    - `meta` (object) - Arbitrary metadata
-        - `user` (array[String Pair]) - User-specific metadata. Metadata written in the source.
-        - `adapter` (array[String Pair]) - Serialization-specific metadata. Metadata provided by adapter.
+    - `meta` (array[Member Element]) - Arbitrary metadata
+
+        Note the "class" of the Member Element can be used to distinguish the
+        source of metadata as follows:
+
+        - Class `user` - User-specific metadata. Metadata written in the source.
+        - Class `adapter` - Serialization-specific metadata. Metadata provided by adapter.
 
 - `content` (array[Element])
 
@@ -61,14 +65,24 @@ For example a `category` element may be classified both as `resourceGroup` and
         "title": "Polls API"
     },
     "attributes": {
-        "meta": {
-            "user": [
-                {
-                    "key":  "HOST",
-                    "value": "http://polls.apiblueprint.org/"
-                }
-            ]
-        }
+        "meta": [
+            {
+              "element": "member",
+              "meta": {
+                  "class": ["user"]
+              },
+              "content": {
+                  "key": {
+                      "element": "string",
+                      "content": "HOST",
+                  },
+                  "value": {
+                      "element": "string",
+                      "content": "http://polls.apiblueprint.org/"
+                  }
+              }
+            }
+        ]
     },
     "content": [
         {
@@ -139,15 +153,6 @@ Given an API description with following layout:
     ]
 }
 ```
-
-## String Pair (object)
-
-Key-value pair where both key and value are of a string type.
-
-### Properties
-
-- `key` (string, required) - Key for the metadata
-- `value` (string, optional) - Value for the metadata
 
 ---
 


### PR DESCRIPTION
This pull requests introduces arbitrary metadata on the grouping level. 

Note in a future this can be done – in theory – on any level. At this moment 
the metadata are plain textual (string) key-value pairs. 

The `meta` attribute is a hash of metadata from different sources. The sources 
can be either user (author – writer – of the source file) or adapter (that 
"loaded" the source file into API refract). 

The "adapter" metadata are currently not used and reserved for future use of 
adapters. For example adapter version or information about the source file. 

The "user" metadata can be used to hold any metadata as specified in the source
file by the user. For example consider following blueprint: 

``` apib
HOST: http://my.api.into
FORMAT: 1A
Author: Z
Email: z@apiary.io

# My API
```

Note the adapter – parser – SHOULD NOT have semantic understanding to the 
"user" metadata.

Remarks & improvements welcomed!
