### PR TITLE
Inhertiance and Ref element

### DIFF
--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -438,9 +438,14 @@ Enumeration type. Exclusive list of possible elements. The elements in content's
 
 #### MSON
 
+```apib
+# User (object)
+- name: John
 ```
+
+```apib
 - id
-- Include User
+- Include (User)
 ```
 
 #### MSON Refract
@@ -493,7 +498,22 @@ Using "Type Reference" (`ref`) element with the `resolved` attribute:
                     "element": "object",
                     "meta": {
                         "ref": "User"
-                    }
+                    },
+                    "content": [
+                        {
+                            "element": "member",
+                            "content": {
+                                "key": {
+                                    "element": "string",
+                                    "content": "name"
+                                },
+                                "value": {
+                                    "element": "string",
+                                    "content": "John"
+                                }
+                            }
+                        }
+                    ]
                 }
             },
             "content": {
@@ -535,7 +555,7 @@ Description is here! Properties to follow.
             "content": {
                 "key": {
                     "element": "string",
-                    "content": "stree"
+                    "content": "street"
                 }
             }
         }

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -42,6 +42,56 @@ This document conforms to RFC 2119, which says:
 
 [MSON][] is used throughout this document.
 
+## Inheritance
+
+MSON namespace uses different set of rules to Basic Refract Specification to express inheritance.
+
+Extending the element "A" to form new element "B":
+
+```json
+{
+  "element": "extend",
+  "meta": {
+    "id": "B"
+  },
+  "content": [
+    {
+      "element": "string",
+      "meta": {
+        "id": "A"
+      },
+      "content": "base element content"
+    },
+    {
+      "element": "string",
+      "content": "derived content"
+    }
+  ]
+}
+```
+
+In MSON refract, the following is equivalent:
+
+```json
+{
+  "element": "string",
+  "meta": {
+    "id": "A"
+  },
+  "content": "base element content"
+}
+```
+
+```json
+{
+  "element": "A",
+  "meta": {
+    "id": "B"
+  },
+  "content": "derived content"
+}
+```
+
 ## Expanded Element
 
 MSON is built around the idea of defining recursive data structures. To provide abstraction, for convenience reasons and to not repeat ourselves, these structures can be named (using an _identifier_) and reused. In [MSON][], the reusable data structures are called _Named Types_.

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -52,7 +52,7 @@ Often, before an MSON Refract can be processed, referenced _Named Types_ have to
 
 In other words, an expanded element is one that does not contain any _Identifier_ (defined below) referencing any other elements than those defined in MSON namespaces.
 
-The expanded Refract MUST, however, keep the track of what data structure was expanded and what from where and it MUST preserve the order of any member elements. 
+The expanded Refract MUST, however, keep the track of what data structure was expanded and what from where and it MUST preserve the order of any member elements.
 
 ### Example
 
@@ -80,7 +80,7 @@ Extending the element "A" to form new element "B":
 }
 ```
 
-Because if the implicit inheritance in MSON namespace the example above can be
+Because of the implicit inheritance in MSON namespace, the example above can be
 written as follows:
 
 ```json

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -80,7 +80,7 @@ Extending the element "A" to form new element "B":
 }
 ```
 
-Because of the implicit inheritance in MSON namespace, the example above can be
+Because of the implicit inheritance in the MSON namespace, the example above can be
 written as follows:
 
 ```json

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -52,7 +52,7 @@ Often, before an MSON Refract can be processed, referenced _Named Types_ have to
 
 In other words, an expanded element is one that does not contain any _Identifier_ (defined below) referencing any other elements than those defined in MSON namespaces.
 
-The expanded Refract MUST, however, keep the track of what data structure was expanded and what from where.
+The expanded Refract MUST, however, keep the track of what data structure was expanded and what from where and it MUST preserve the order of any member elements. 
 
 ### Example
 
@@ -80,7 +80,8 @@ Extending the element "A" to form new element "B":
 }
 ```
 
-In MSON refract, the following is equivalent:
+Because if the implicit inheritance in MSON namespace the example above can be
+written as follows:
 
 ```json
 {
@@ -102,7 +103,8 @@ In MSON refract, the following is equivalent:
 }
 ```
 
-Finally, using the `extend` element to expand the MSON refract for id "B":
+Resolving the MSON namespace implicit inheritance and expanding the references
+from the example above we get:
 
 ```json
 {

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -42,9 +42,19 @@ This document conforms to RFC 2119, which says:
 
 [MSON][] is used throughout this document.
 
-## Inheritance
+## Inheritance and Expanded Element
 
-MSON namespace uses different set of rules to Basic Refract Specification to express inheritance.
+MSON is built around the idea of defining recursive data structures. To provide abstraction, for convenience reasons and to not repeat ourselves, these structures can be named (using an _identifier_) and reused. In [MSON][], the reusable data structures are called _Named Types_.
+
+By default, Refract does not enforce inheritance of data, though element definitions are inherited from the defined element types. To inherit data in Refract, the `extend` element is used to merge one or more elements into a final element. In the MSON namespace, however, when the data is defined, it inherits data from the element definition. MSON itself uses inheritance this way, and the MSON Refract namespace mimics the behavior to provide simplicity and consistency across MSON representations.
+
+Often, before an MSON Refract can be processed, referenced _Named Types_ have to be resolved. Resolving references to _Named Types_ is tedious and error prone. As such an MSON processor can resolve references to produce a complete MSON Refract. That is, a Refract that does not include unresolved references to other data structures. This is referred to as _reference expansion_ or simply _expansion_.
+
+In other words, an expanded element is one that does not contain any _Identifier_ (defined below) referencing any other elements than those defined in MSON namespaces.
+
+The expanded Refract MUST, however, keep the track of what data structure was expanded and what from where.
+
+### Example
 
 Extending the element "A" to form new element "B":
 
@@ -92,17 +102,29 @@ In MSON refract, the following is equivalent:
 }
 ```
 
-## Expanded Element
+Finally, using the `extend` element to expand the MSON refract for id "B":
 
-MSON is built around the idea of defining recursive data structures. To provide abstraction, for convenience reasons and to not repeat ourselves, these structures can be named (using an _identifier_) and reused. In [MSON][], the reusable data structures are called _Named Types_.
-
-By default, Refract does not enforce inheritance of data, though element definitions are inherited from the defined element types. To inherit data in Refract, the `extend` element is used to merge one or more elements into a final element. In the MSON namespace, however, when the data is defined, it inherits data from the element definition. MSON itself uses inheritance this way, and the MSON Refract namespace mimics the behavior to provide simplicity and consistency across MSON representations.
-
-Often, before an MSON Refract can be processed, referenced _Named Types_ have to be resolved. Resolving references to _Named Types_ is tedious and error prone. As such an MSON processor can resolve references to produce a complete MSON Refract. That is, a Refract that does not include unresolved references to other data structures. This is referred to as _reference expansion_ or simply _expansion_.
-
-In other words, an expanded element is one that does not contain any _Identifier_ (defined below) referencing any other elements than those defined in MSON namespaces.
-
-The expanded Refract MUST, however, keep the track of what data structure was expanded and what from where.
+```json
+{
+  "element": "extend",
+  "meta": {
+    "id": "B"
+  },
+  "content": [
+    {
+      "element": "string",
+      "meta": {
+        "ref": "A"
+      },
+      "content": "base element content"
+    },
+    {
+      "element": "string",
+      "content": "derived content"
+    }
+  ]
+}
+```
 
 ## Base Element
 

--- a/namespaces/mson-namespace.md
+++ b/namespaces/mson-namespace.md
@@ -6,32 +6,32 @@ This document extends [Refract][] Specification with new element types necessary
 
 <!-- TOC depth:3 withLinks:1 updateOnSave:0 -->
 - [MSON Namespace](#mson-namespace)
-    - [Content](#content)
-    - [About this Document](#about-this-document)
-    - [Expanded Element](#expanded-element)
-    - [Base Element](#base-element)
-        - [Type comparison](#type-comparison)
+	- [Content](#content)
+	- [About this Document](#about-this-document)
+	- [Inheritance and Expanded Element](#inheritance-and-expanded-element)
+	- [Base Element](#base-element)
+		- [Type comparison](#type-comparison)
 - [MSON Refract Elements](#mson-refract-elements)
-    - [MSON Element (Element)](#mson-element-element)
-        - [Properties](#properties)
-    - [Boolean Type (Boolean Element)](#boolean-type-boolean-element)
-    - [String Type (String Element)](#string-type-string-element)
-    - [Number Type (Number Element)](#number-type-number-element)
-    - [Array Type (Array Element)](#array-type-array-element)
-    - [Object Type (Object Element)](#object-type-object-element)
-    - [Enum Type (MSON Element)](#enum-type-mson-element)
-        - [Properties](#properties)
-        - [Examples](#examples)
-    - [Examples](#examples)
-        - [Anonymous Object Type](#anonymous-object-type)
-        - [Type Attributes](#type-attributes)
-        - [Default Value](#default-value)
-        - [One Of](#one-of)
-        - [Mixin](#mixin)
-        - [Named Type](#named-type)
-        - [Variable Value](#variable-value)
-        - [Variable Property Name](#variable-property-name)
-        - [Variable Type Name](#variable-type-name)
+	- [MSON Element (Element)](#mson-element-element)
+	- [Type Reference (Ref Element)](#type-reference-ref-element)
+	- [Boolean Type (Boolean Element)](#boolean-type-boolean-element)
+	- [String Type (String Element)](#string-type-string-element)
+	- [Number Type (Number Element)](#number-type-number-element)
+	- [Array Type (Array Element)](#array-type-array-element)
+	- [Object Type (Object Element)](#object-type-object-element)
+	- [Enum Type (MSON Element)](#enum-type-mson-element)
+	- [Examples](#examples)
+		- [Anonymous Object Type](#anonymous-object-type)
+		- [Type Attributes](#type-attributes)
+		- [Default Value](#default-value)
+		- [One Of](#one-of)
+		- [Mixin](#mixin)
+		- [Named Type](#named-type)
+		- [Referencing & Expansion](#referencing-expansion)
+		- [Variable Value](#variable-value)
+		- [Variable Property Name](#variable-property-name)
+		- [Variable Type Name](#variable-type-name)
+
 <!-- /TOC -->
 
 ## About this Document
@@ -186,6 +186,15 @@ Note: In MSON Refract _Nested Member Types_ _Type Section_ is the `content` of t
 
     - `validation` - Not used, reserved for a future use
 
+## Type Reference (Ref Element)
+
+This elements extends refract `Ref Element` to include optional referenced element.
+
+### Properties
+
+- `element` ref (string, fixed)
+- `attributes`
+    -  `resolved` (Element, optional) - Resolved element being referenced.
 
 ## Boolean Type (Boolean Element)
 
@@ -462,29 +471,35 @@ Using the `ref` element to reference an the content of an element.
 }
 ```
 
-Using `extend` to merge objects together.
+Using "Type Reference" (`ref`) element with the `resolved` attribute:
 
 ```json
 {
-    "element": "extend",
+    "element": "object",
     "content": [
         {
-            "element": "object",
-            "content": [
-                {
-                    "element": "member",
-                    "content": {
-                        "key": {
-                            "element": "string",
-                            "content": "id"
-                        }
-                    }
+            "element": "member",
+            "content": {
+                "key": {
+                    "element": "string",
+                    "content": "id"
                 }
-            ]
+            }
         },
         {
             "element": "ref",
-            "content": "User"
+            "attributes": {
+                "resolved": {
+                    "element": "object",
+                    "meta": {
+                        "ref": "User"
+                    }
+                }
+            },
+            "content": {
+                "href": "User",
+                "path": "content"
+            }
         }
     ]
 }


### PR DESCRIPTION
This PR brings additional example on differences between the base spec and MSON inheritance. 

This PR also introduces the `resolved` attribute for the `ref` element. This attribute is to be used to hold any resolved (see MSON expand) element referred by the `ref` element.

Finally this PR updates the mixin example using newly introduced resolved attribute.
