### PR TITLE
Description of a resource group should be a copy element in example

### DIFF
--- a/namespaces/api-description-namespace.md
+++ b/namespaces/api-description-namespace.md
@@ -272,10 +272,14 @@ transitions.
                 "class": [
                     "resourceGroup"
                 ],
-                "title": "Question",
-                "description": "Resources related to questions in the API."
+                "title": "Question"
             },
-            "content": []
+            "content": [
+                {
+                    "element": "copy",
+                    "content": "Resources related to questions in the API."
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
This is how it is currently designed in snowcrash so that we can allow future description/`copy` elements in between resources.
