### PR TITLE
Moves Compact Refract to separate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to the Refract project will be documented in this file.
 
+## Unreleased changes
+- Moved Compact Refract out of base specification
+
 ## [0.6.0] - 2015-12-15
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ Refract is a recursive data structure for expressing complex structures, relatio
 
 ## Version
 
-**Current Version**: 0.6.0
+**Current Version**: 0.7.0
 
 **Note**: This specification is currently in development and may change before getting to a more stable 1.0 version. Please be mindful of this if using this production environments.
+
+## Serialization Formats
+
+- [Compact Refract](formats/compact-refract.md)
 
 ## Libraries
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Refract is a recursive data structure for expressing complex structures, relatio
 
 ## Version
 
-**Current Version**: 0.7.0
+**Current Version**: 0.6.0
 
 **Note**: This specification is currently in development and may change before getting to a more stable 1.0 version. Please be mindful of this if using this production environments.
 

--- a/formats/compact-refract.md
+++ b/formats/compact-refract.md
@@ -1,0 +1,96 @@
+# Compact Refract
+
+Compact Refract is a serialization format Refract for the purpose of removing a
+lot of the object keys that are repeated throughout the full serialization of
+Refract, as seen in the Refract specification. It also allows for expressing
+structures in a tuple, which resembles other formats like XML or Lisp.
+
+## Dependencies
+
+- [Refract Base
+Specification](https://github.com/refractproject/refract-spec/blob/master/refract-spec.md)
+  - Only Include
+    - Element Pointer
+
+## Data Structures
+
+### Compact Element (array)
+
+The Compact Element is a tuple where each item has a specific meaning. The
+first item is the element name, the second is the meta attribute section, the
+third is the attribute section, and the fourth is the content section.
+
+#### Members
+
+- (string, required) - Name of the element
+- (Meta Attributes, required) - Meta attributes of the element instance.
+- (object, required) - Attributes of the element instance
+- (enum, required) - Element content with any of the following types
+  - (null)
+  - (string)
+  - (number)
+  - (boolean)
+  - (array)
+  - (object)
+  - (Compact Element)
+  - (array[Compact Element])
+
+## Meta Attributes
+
+The Meta Attributes are similar to those defined by the base specification,
+though the only difference is that Link Elements are of a different structure.
+
+### Members
+
+- `id` - Unique Identifier, MUST be unique throughout the document
+- `ref` (Element Pointer) - Pointer to referenced element or type
+- `classes` (array[string]) - Array of classifications for given element
+- `title` (string) - Human-readable title of element
+- `description` (string) - Human-readable description of element
+- `links` (array[Link Element]) - Meta links for a given element
+
+## Link Element (array)
+
+Allow for hyperlinking within a Refract document. Note that this Link Element
+is different than the Link Element in the base specification.
+
+### Members
+
+- link (string, fixed)
+- (Meta Attributes)
+- (object)
+  - relation (string) - Link relation type as specified in RFC 5988.
+  - href (string) - The URI for the given link
+
+## Example
+
+In the base specification, serialization looks something like this for JSON:
+
+```json
+{
+  "element": "foo",
+  "content": "bar"
+}
+```
+
+In Compact Refract, this same example looks like this:
+
+```json
+["foo", {}, {}, "bar"]
+```
+
+In this example, meta attributes and attributes are both required, even if the
+objects are empty. This is because this format relies on the structure of the
+array in order to determine values.
+
+## Pros and Cons
+
+The benefits as mentioned are that this is a more concise format. In some
+cases, it may even be easier to write, or convert from other formats such as
+XML or Lisp.
+
+One downside of this format is that there is no simple way to distinguish a
+normal array from a Compact Refract array. This makes it hard to embed Refract
+within normal data structures, requiring that either the entire structure be
+converted to Compact Refract, or that the user relies on domain-specific
+information.

--- a/formats/compact-refract.md
+++ b/formats/compact-refract.md
@@ -18,6 +18,13 @@ The Compact Element is a tuple where each item has a specific meaning. The
 first item is the element name, the second is the meta attribute section, the
 third is the attribute section, and the fourth is the content section.
 
+The downside of this format is that there is no way to distinguish between a
+normal array and a Compact Element. Because of this, in situations where there
+is ambiguity, the array SHOULD be treated as a normal array and handled
+accordingly. Ambiguity arises when an array is found in areas such as
+`attributes` or `content` and requires out-of-band information how to handle
+the array.
+
 #### Members
 
 - (string, required) - Name of the element

--- a/formats/compact-refract.md
+++ b/formats/compact-refract.md
@@ -9,8 +9,6 @@ structures in a tuple, which resembles other formats like XML or Lisp.
 
 - [Refract Base
 Specification](https://github.com/refractproject/refract-spec/blob/master/refract-spec.md)
-  - Only Include
-    - Element Pointer
 
 ## Data Structures
 
@@ -23,7 +21,13 @@ third is the attribute section, and the fourth is the content section.
 #### Members
 
 - (string, required) - Name of the element
-- (Meta Attributes, required) - Meta attributes of the element instance.
+- (object, required) - Meta attributes of the element instance.
+  - `id` - Unique Identifier, MUST be unique throughout the document
+  - `ref` (Element Pointer) - Pointer to referenced element or type
+  - `classes` (array[string]) - Array of classifications for given element
+  - `title` (string) - Human-readable title of element
+  - `description` (string) - Human-readable description of element
+  - `links` (array[Link Element]) - Meta links for a given element
 - (object, required) - Attributes of the element instance
 - (enum, required) - Element content with any of the following types
   - (null)
@@ -34,33 +38,6 @@ third is the attribute section, and the fourth is the content section.
   - (object)
   - (Compact Element)
   - (array[Compact Element])
-
-## Meta Attributes
-
-The Meta Attributes are similar to those defined by the base specification,
-though the only difference is that Link Elements are of a different structure.
-
-### Members
-
-- `id` - Unique Identifier, MUST be unique throughout the document
-- `ref` (Element Pointer) - Pointer to referenced element or type
-- `classes` (array[string]) - Array of classifications for given element
-- `title` (string) - Human-readable title of element
-- `description` (string) - Human-readable description of element
-- `links` (array[Link Element]) - Meta links for a given element
-
-## Link Element (array)
-
-Allow for hyperlinking within a Refract document. Note that this Link Element
-is different than the Link Element in the base specification.
-
-### Members
-
-- link (string, fixed)
-- (Meta Attributes)
-- (object)
-  - relation (string) - Link relation type as specified in RFC 5988.
-  - href (string) - The URI for the given link
 
 ## Example
 

--- a/refract-spec.md
+++ b/refract-spec.md
@@ -87,50 +87,6 @@ An element MAY look like this, where `foo` is the element name, `id` is a meta a
 }
 ```
 
-### Compact Format
-
-In addition to expressing Refract Elements as objects with `element`, `meta`, `attributes`, and `content` properties, these elements MUST be expressed as a tuple.
-
-#### Compact Element (array)
-
-The Compact Element is a tuple where each item has a specific meaning. The first item is the element name, the second is the meta attribute section, the third is the attribute section, and the fourth is the content section.
-
-##### Members
-
-- (string, required) - Name of the element
-- (enum, required) - Meta attributes of the element instance. See meta attributes above for full Refract representation
-    - (object)
-    - (array[Compact Element])
-- (enum, required) - Attributes of the element instance
-    - (object)
-    - (array[Compact Element])
-- (enum, required) - Element content with any of the following types
-  - (null)
-  - (string)
-  - (number)
-  - (boolean)
-  - (array)
-  - (object)
-  - (Compact Element)
-  - (array[Compact Element])
-
-##### Example
-
-Below is a Refract element `foo` that is expressed in the normal Refract representation.
-
-```json
-{
-  "element": "foo",
-  "content": "bar"
-}
-```
-
-This is how it would represented in the compact version.
-
-```json
-["foo", {}, {}, "bar"]
-```
-
 ## Primitive Elements
 
 Primitive Elements extend upon the base Element to define elements based on the Primitive Types of Refract.


### PR DESCRIPTION
This moves Compact Refract out of the base spec to its own spec. Note that this does in a sense break the spec, but it also simplifies that clients do not need to support it to support the base spec. This is the reason for bumping the version number.

Another thing to note is that I have not defined all primitive elements here. For one, I’m trying to work through this quickly and I want to consider this to be a serialization format and not defining a specific structure like the base spec does.
