### PR TITLE
Introducing JSON serialisation guidelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: python
+install: pip install jsonschema-test
+script: jsonschema-test formats/json-refract-schema.json formats/json-refract-schema-tests.json

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Refract is a recursive data structure for expressing complex structures, relatio
 
 ## Serialization Formats
 
-- [Compact Refract](formats/compact-refract.md)
+- [JSON Refract](formats/json-refract.md)
+- [JSON Compact Refract](formats/json-compact-refract.md)
 
 ## Libraries
 

--- a/formats/json-compact-refract.md
+++ b/formats/json-compact-refract.md
@@ -1,9 +1,10 @@
-# Compact Refract
+# JSON Compact Refract
 
-Compact Refract is a serialization format Refract for the purpose of removing a
-lot of the object keys that are repeated throughout the full serialization of
-Refract, as seen in the Refract specification. It also allows for expressing
-structures in a tuple, which resembles other formats like XML or Lisp.
+JSON Compact Refract is a serialization format Refract for the purpose of
+removing a lot of the object keys that are repeated throughout the full
+serialization of Refract, as seen in the Refract specification. It also allows
+for expressing structures in a tuple, which resembles other formats like XML or
+Lisp.
 
 ## Dependencies
 

--- a/formats/json-refract-schema-tests.json
+++ b/formats/json-refract-schema-tests.json
@@ -356,6 +356,18 @@
         "valid": false
       },
       {
+        "description": "with an array as classes",
+        "data": {
+          "element": "string",
+          "meta": {
+            "classes": [
+              "api"
+            ]
+          }
+        },
+        "valid": false
+      },
+      {
         "description": "with array element as links",
         "data": {
           "element": "string",

--- a/formats/json-refract-schema-tests.json
+++ b/formats/json-refract-schema-tests.json
@@ -1,0 +1,586 @@
+[
+  {
+    "description": "an element name",
+    "tests": [
+      {
+        "description": "with valid element name",
+        "data": {
+          "element": "string"
+        },
+        "valid": true
+      },
+      {
+        "description": "without an element name",
+        "data": {},
+        "valid": false
+      },
+      {
+        "description": "with an element name that is not a string",
+        "data": {
+          "element": null
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "an element content",
+    "tests": [
+      {
+        "description": "without content",
+        "data": {
+          "element": "string"
+        },
+        "valid": true
+      },
+      {
+        "description": "with string content",
+        "data": {
+          "element": "string",
+          "content": "Hello World"
+        },
+        "valid": true
+      },
+      {
+        "description": "with number content",
+        "data": {
+          "element": "number",
+          "content": 1
+        },
+        "valid": true
+      },
+      {
+        "description": "with boolean content",
+        "data": {
+          "element": "boolean",
+          "content": true
+        },
+        "valid": true
+      },
+      {
+        "description": "with null content",
+        "data": {
+          "element": "null",
+          "content": null
+        },
+        "valid": true
+      },
+      {
+        "description": "with element content",
+        "data": {
+          "element": "custom",
+          "content": {
+            "element": "string"
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with array of element content",
+        "data": {
+          "element": "custom",
+          "content": [
+            {
+              "element": "string"
+            }
+          ]
+        },
+        "valid": true
+      },
+      {
+        "description": "with key value pair element content",
+        "data": {
+          "element": "custom",
+          "content": {
+            "key": {
+              "element": "string"
+            },
+            "value": {
+              "element": "string"
+            }
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with array of non-element content",
+        "data": {
+          "element": "custom",
+          "content": [
+            "hello"
+          ]
+        },
+        "valid": false
+      },
+      {
+        "description": "with object as content",
+        "data": {
+          "element": "custom",
+          "content": {
+            "something": "value"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with key value pair with additional properties element content",
+        "data": {
+          "element": "custom",
+          "content": {
+            "key": {
+              "element": "string"
+            },
+            "value": {
+              "element": "string"
+            },
+            "additional": "property"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with key value pair without value element content",
+        "data": {
+          "element": "custom",
+          "content": {
+            "key": {
+              "element": "string"
+            }
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with key value pair without key element content",
+        "data": {
+          "element": "custom",
+          "content": {
+            "value": {
+              "element": "string"
+            }
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with key value pair with key that is not an element content",
+        "data": {
+          "element": "custom",
+          "content": {
+            "key": {
+              "a": "bc"
+            }
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with key value pair with value that is not an element content",
+        "data": {
+          "element": "custom",
+          "content": {
+            "key": {
+              "element": "string"
+            },
+            "value": "test"
+          }
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "an element meta",
+    "tests": [
+      {
+        "description": "with non-object meta",
+        "data": {
+          "element": "string",
+          "meta": null
+        },
+        "valid": false
+      },
+      {
+        "description": "with id metadata",
+        "data": {
+          "element": "string",
+          "meta": {
+            "id": {
+              "element": "string",
+              "content": "Name"
+            }
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with non-element id metadata",
+        "data": {
+          "element": "string",
+          "meta": {
+            "id": "Name"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with title metadata",
+        "data": {
+          "element": "string",
+          "meta": {
+            "title": {
+              "element": "string",
+              "content": "Doe"
+            }
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with title metadata as non string element",
+        "data": {
+          "element": "string",
+          "meta": {
+            "title": {
+              "element": "number",
+              "content": 1
+            }
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with non-element title metadata",
+        "data": {
+          "element": "string",
+          "meta": {
+            "title": "Doe"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with description metadata",
+        "data": {
+          "element": "string",
+          "meta": {
+            "description": {
+              "element": "string",
+              "content": "Doe"
+            }
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with description metadata as non string element",
+        "data": {
+          "element": "string",
+          "meta": {
+            "description": {
+              "element": "number",
+              "content": 1
+            }
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with non-element description metadata",
+        "data": {
+          "element": "string",
+          "meta": {
+            "description": "Doe"
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with unknown meta key",
+        "data": {
+          "element": "string",
+          "meta": {
+            "something": {
+              "element": "string",
+              "content": "Name"
+            }
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with array element as classes",
+        "data": {
+          "element": "string",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "string",
+                  "content": "error"
+                }
+              ]
+            }
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with array element of non string element as classes",
+        "data": {
+          "element": "string",
+          "meta": {
+            "classes": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "number"
+                }
+              ]
+            }
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with non array element as classes",
+        "data": {
+          "element": "string",
+          "meta": {
+            "classes": {
+              "element": "string"
+            }
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with array element as links",
+        "data": {
+          "element": "string",
+          "meta": {
+            "links": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "link"
+                }
+              ]
+            }
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with array element of non link element as links",
+        "data": {
+          "element": "string",
+          "meta": {
+            "links": {
+              "element": "array",
+              "content": [
+                {
+                  "element": "number"
+                }
+              ]
+            }
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with non array element as links",
+        "data": {
+          "element": "string",
+          "meta": {
+            "links": {
+              "element": "string"
+            }
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with element pointer as ref",
+        "data": {
+          "element": "string",
+          "meta": {
+            "ref": {
+              "element": "elementPointer",
+              "content": "Thing"
+            }
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with element pointer with element path as ref",
+        "data": {
+          "element": "string",
+          "meta": {
+            "ref": {
+              "element": "elementPointer",
+              "attributes": {
+                "path": {
+                  "element": "string",
+                  "content": "element"
+                }
+              },
+              "content": "Thing"
+            }
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with element pointer with meta path as ref",
+        "data": {
+          "element": "string",
+          "meta": {
+            "ref": {
+              "element": "elementPointer",
+              "attributes": {
+                "path": {
+                  "element": "string",
+                  "content": "meta"
+                }
+              },
+              "content": "Thing"
+            }
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with element pointer with attributes path as ref",
+        "data": {
+          "element": "string",
+          "meta": {
+            "ref": {
+              "element": "elementPointer",
+              "attributes": {
+                "path": {
+                  "element": "string",
+                  "content": "attributes"
+                }
+              },
+              "content": "Thing"
+            }
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with element pointer with content path as ref",
+        "data": {
+          "element": "string",
+          "meta": {
+            "ref": {
+              "element": "elementPointer",
+              "attributes": {
+                "path": {
+                  "element": "string",
+                  "content": "content"
+                }
+              },
+              "content": "Thing"
+            }
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with element pointer with invalid path as ref",
+        "data": {
+          "element": "string",
+          "meta": {
+            "ref": {
+              "element": "elementPointer",
+              "attributes": {
+                "path": {
+                  "element": "string",
+                  "content": "unknown"
+                }
+              },
+              "content": "Thing"
+            }
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with element pointer without content as ref",
+        "data": {
+          "element": "string",
+          "meta": {
+            "ref": {
+              "element": "elementPointer"
+            }
+          }
+        },
+        "valid": false
+      },
+      {
+        "description": "with non element pointer as ref",
+        "data": {
+          "element": "string",
+          "meta": {
+            "ref": {
+              "element": "string"
+            }
+          }
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "an element attributes",
+    "tests": [
+      {
+        "description": "with non-object attributes",
+        "data": {
+          "element": "string",
+          "attributes": null
+        },
+        "valid": false
+      },
+      {
+        "description": "with attributes with element value",
+        "data": {
+          "element": "string",
+          "attributes": {
+            "name": {
+              "element": "string"
+            }
+          }
+        },
+        "valid": true
+      },
+      {
+        "description": "with attributes with non element value",
+        "data": {
+          "element": "string",
+          "attributes": {
+            "name": "string"
+          }
+        },
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "an element",
+    "tests": [
+      {
+        "description": "with additional properties",
+        "data": {
+          "element": "string",
+          "additional": "properties"
+        },
+        "valid": false
+      }
+    ]
+  }
+]

--- a/formats/json-refract-schema.json
+++ b/formats/json-refract-schema.json
@@ -1,0 +1,180 @@
+{
+  "oneOf": [
+    { "$ref": "#/definitions/element" }
+  ],
+  "definitions": {
+    "element": {
+      "title": "Element",
+      "type": "object",
+      "properties": {
+        "element": {
+          "type": "string"
+        },
+        "meta": {
+          "type": "object",
+          "properties": {
+            "id": { "$ref": "#/definitions/element" },
+            "title": { "$ref": "#/definitions/string-element" },
+            "description": { "$ref": "#/definitions/string-element" },
+            "ref": { "$ref": "#/definitions/element-pointer" },
+            "classes": { "$ref": "#/definitions/array-string-element" },
+            "links": { "$ref": "#/definitions/array-link-element" }
+          },
+          "additionalProperties": false
+        },
+        "attributes": {
+          "type": "object",
+          "patternProperties": {
+            "": {
+              "$ref": "#/definitions/element"
+            }
+          }
+        },
+        "content": {
+          "oneOf": [
+            {
+              "type": [
+                "string",
+                "number",
+                "boolean",
+                "null",
+                "array"
+              ],
+              "items": {
+                "$ref": "#/definitions/element"
+              }
+            },
+            {
+              "$ref": "#/definitions/element"
+            },
+            {
+              "$ref": "#/definitions/key-value-pair"
+            }
+          ]
+        }
+      },
+      "required": [
+        "element"
+      ],
+      "additionalProperties": false
+    },
+    "key-value-pair": {
+      "title": "Key Value Pair",
+      "type": "object",
+      "properties": {
+        "key": {
+          "$ref": "#/definitions/element"
+        },
+        "value": {
+          "$ref": "#/definitions/element"
+        }
+      },
+      "required": ["key"],
+      "additionalProperties": false
+    },
+    "string-element": {
+      "title": "String Element",
+      "allOf": [
+        { "$ref": "#/definitions/element" },
+        {
+          "properties": {
+            "element": {
+              "enum": ["string"]
+            },
+            "content": {
+              "type": ["string"]
+            }
+          }
+        }
+      ]
+    },
+    "array-element": {
+      "title": "Array Element",
+      "allOf": [
+        { "$ref": "#/definitions/element" },
+        {
+          "properties": {
+            "element": {
+              "enum": ["array"]
+            },
+            "content": {
+              "type": ["array"]
+            }
+          }
+        }
+      ]
+    },
+    "array-string-element": {
+      "title": "Array Element of String Element",
+      "allOf": [
+        { "$ref": "#/definitions/array-element" },
+        {
+          "properties": {
+            "content": {
+              "items": { "$ref": "#/definitions/string-element" }
+            }
+          }
+        }
+      ]
+    },
+    "link-element": {
+      "title": "Link Element",
+      "allOf": [
+        { "$ref": "#/definitions/element" },
+        {
+          "properties": {
+            "element": {
+              "enum": ["link"]
+            }
+          }
+        }
+      ]
+    },
+    "array-link-element": {
+      "title": "Array Element of Link Element",
+      "allOf": [
+        { "$ref": "#/definitions/array-element" },
+        {
+          "properties": {
+            "content": {
+              "items": { "$ref": "#/definitions/link-element" }
+            }
+          }
+        }
+      ]
+    },
+    "element-pointer": {
+      "title": "Element Pointer",
+      "allOf": [
+        { "$ref": "#/definitions/element" },
+        {
+          "properties": {
+            "element": {
+              "enum": ["elementPointer"]
+            },
+            "content": {
+              "type": ["string"]
+            },
+            "attributes": {
+              "properties": {
+                "path": {
+                  "allOf": [
+                    { "$ref": "#/definitions/string-element" },
+                    {
+                      "properties": {
+                        "content": {
+                          "enum": ["element", "meta", "attributes", "content"]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "required": ["content"]
+        }
+      ]
+    }
+  }
+}

--- a/formats/json-refract.md
+++ b/formats/json-refract.md
@@ -117,7 +117,7 @@ An element is not required to have content.
 ```json
 {
   "element": "member",
-  "content: {
+  "content": {
     "key": {
       "element": "string",
       "content": "Name"

--- a/formats/json-refract.md
+++ b/formats/json-refract.md
@@ -1,0 +1,151 @@
+# JSON Refract Serialisation
+
+This document describes how Refract can be serialised into other forms such as
+JSON along with including all serialisation guidelines.
+
+A Refract element MUST be serialised fully as the following data structure as a
+JSON object:
+
+- element (required, string)
+- meta (optional, object)
+- attributes (optional, object)
+- content (optional, enum)
+    - Element
+    - array[Element]
+    - string
+    - boolean
+    - number
+    - null
+    - Key Value Pair
+
+## Properties
+
+### Element
+
+The element name MUST always be present and it MUST contain the name of the
+Refract element as a string.
+
+### Meta
+
+Meta will contain all the meta properties, this SHOULD NOT be present in the
+serialisation if there are no meta properties. When there are any meta
+properties set, the meta SHOULD be serialised. Meta SHOULD contain a JSON
+object which matches the keys and values described in the Refract
+specification. All values in the object must be Refracted elements.
+
+### Attributes
+
+Attributes will contain all the attributes of an element, this SHOULD NOT be
+present in the serialisation if there are no attributes. When there are any
+attributes set, the attributes SHOULD be serialised. Attributes SHOULD contain
+a JSON object which contains the attributes in the Refract specification. All
+attribute values in the JSON object must be Refracted elements.
+
+### Content
+
+The content of an element MUST be one of the following types:
+
+- Element - Another JSON serialised element
+- array[Element] - An array of JSON serialised elements
+- string - A JSON string
+- boolean - A JSON boolean value (true/false)
+- number - A JSON number
+- null - A JSON null (`null`)
+- Key Value Pair (object) - A JSON object representing a key-value pair
+    - key (required, Element) - A required key
+    - value (Element) - An optional value
+
+An element is not required to have content.
+
+## Examples
+
+### An element
+
+```json
+{
+  "element": "string"
+}
+```
+
+### An element with content
+
+```json
+{
+  "element": "string",
+  "content": "Doe"
+}
+```
+
+### An element with metadata and content
+
+```json
+{
+  "element": "string",
+  "meta": {
+    "title": {
+      "element": "string",
+      "content": "Name"
+    }
+  },
+  "content": "Doe"
+}
+```
+
+### An element with metadata, attributes and content
+
+```json
+{
+  "element": "string",
+  "meta": {
+    "title": {
+      "element": "string",
+      "content": "Person"
+    }
+  },
+  "attributes": {
+    "address": {
+      "element": "string",
+      "content": "49 Featherstone Street, London, EC1Y 8SY"
+    }
+  },
+  "content": "Doe"
+}
+```
+
+### An element with Key Value Pair as content
+
+```json
+{
+  "element": "member",
+  "content: {
+    "key": {
+      "element": "string",
+      "content": "Name"
+    },
+    "value": {
+      "element": "string",
+      "content": "Doe"
+    }
+  }
+}
+```
+
+### An element with array of elements as content
+
+```json
+{
+  "element": "dns-resource",
+  "content": [
+    {
+      "element": "dns-record",
+      "attributes": {
+        "ttl": {
+          "element": "number",
+          "content": 86400
+        }
+      },
+      "content": "_sip._tcp.example.com"
+    }
+  ]
+}
+```


### PR DESCRIPTION
This pull request introduces a new document to specify how to serialise a Refract element into JSON.

- It contains a both a specification which contains various examples.
- Renamed the "Compact Serialisation" to become "JSON Compact Serialisation" as this is more accurate.
- There is also a JSON Schema that specifies an element serialised as a JSON Object which can be used for validations. The JSON Schema includes full test coverage using [jsonschema-test](https://github.com/kylef/jsonschema-test), this is something I started in https://github.com/refractproject/refract-spec/pull/10 which is now much simpler to implement with our new serialisation rules.

This PR is part of the implementation for https://github.com/refractproject/rfcs/pull/36 along with #62.

Closes https://github.com/refractproject/refract-spec/issues/59