### PR TITLE
Add examples of serialisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: python
 install: pip install jsonschema-test
-script: jsonschema-test formats/json-refract-schema.json formats/json-refract-schema-tests.json
+script:
+  - jsonschema-test formats/json-refract-schema.json formats/json-refract-schema-tests.json
+  - jsonschema formats/json-refract-schema.json -i formats/examples/element.json
+  - jsonschema formats/json-refract-schema.json -i formats/examples/element-element.json
+  - jsonschema formats/json-refract-schema.json -i formats/examples/element-array.json
+  - jsonschema formats/json-refract-schema.json -i formats/examples/element-kv.json
+  - jsonschema formats/json-refract-schema.json -i formats/examples/element-meta-title.json
+  - jsonschema formats/json-refract-schema.json -i formats/examples/element-attributes.json

--- a/formats/examples/README.md
+++ b/formats/examples/README.md
@@ -1,0 +1,67 @@
+# Refract Examples
+
+This directory contains examples of serialise Refract elements.
+
+## Formats
+
+Examples are supplied for the following formats:
+
+- JSON Serialisation (`.json`)
+- Compact JSON Serialisation (`.compact.json`)
+
+## Files
+
+### Element (`element`)
+
+A basic element with a primitive value as content.
+
+- element: string
+- content: Hello World
+
+### Element Element (`element-element`)
+
+An element which has an element as content.
+
+- element: item
+- content (Element)
+    - element: string
+    - content: value
+
+### Element Array (`element-array`)
+
+An element which has an array of elements as content.
+
+- element: array
+- content (array)
+    - (Element)
+        - element: string
+        - content: Hello World
+
+### Element Key Value Pair (`element-kv`)
+
+- element: member
+- content
+    - key (Element)
+        - element: string
+        - content: Name
+    - value (Element)
+        - element: string
+        - content: Doe
+
+### Element Title Meta (`element-meta-title`)
+
+- element: string
+- meta
+    - title (Element)
+        - element: string
+        - content: Name
+- content: Doe
+
+### Element Attributes (`element-attributes`)
+
+- element: string
+- attributes
+    - method (Element)
+        - element: string
+        - content: GET
+- content: /

--- a/formats/examples/element-array.compact.json
+++ b/formats/examples/element-array.compact.json
@@ -1,0 +1,8 @@
+[
+  "array",
+  null,
+  null,
+  [
+    ["string", null, null, "Hello World"]
+  ]
+]

--- a/formats/examples/element-array.json
+++ b/formats/examples/element-array.json
@@ -1,0 +1,9 @@
+{
+  "element": "array",
+  "content": [
+    {
+      "element": "string",
+      "content": "Hello World"
+    }
+  ]
+}

--- a/formats/examples/element-attributes.compact.json
+++ b/formats/examples/element-attributes.compact.json
@@ -1,0 +1,8 @@
+[
+  "string",
+  null,
+  {
+    "method": ["string", null, null, "GET"]
+  },
+  "/"
+]

--- a/formats/examples/element-attributes.json
+++ b/formats/examples/element-attributes.json
@@ -1,0 +1,10 @@
+{
+  "element": "string",
+  "attributes": {
+    "method": {
+      "element": "string",
+      "content": "GET"
+    }
+  },
+  "content": "/"
+}

--- a/formats/examples/element-element.compact.json
+++ b/formats/examples/element-element.compact.json
@@ -1,0 +1,6 @@
+[
+  "item",
+  null,
+  null,
+  ["string", null, null, "value"]
+]

--- a/formats/examples/element-element.json
+++ b/formats/examples/element-element.json
@@ -1,0 +1,7 @@
+{
+  "element": "item",
+  "content": {
+    "element": "string",
+    "content": "value"
+  }
+}

--- a/formats/examples/element-kv.compact.json
+++ b/formats/examples/element-kv.compact.json
@@ -1,0 +1,10 @@
+[
+  "member",
+  null,
+  null,
+  [
+    "pair",
+    ["string", null, null, "Name"],
+    ["string", null, null, "Doe"]
+  ]
+]

--- a/formats/examples/element-kv.json
+++ b/formats/examples/element-kv.json
@@ -1,0 +1,13 @@
+{
+  "element": "member",
+  "content": {
+    "key": {
+      "element": "string",
+      "content": "Name"
+    },
+    "value": {
+      "element": "string",
+      "content": "Doe"
+    }
+  }
+}

--- a/formats/examples/element-meta-title.compact.json
+++ b/formats/examples/element-meta-title.compact.json
@@ -1,0 +1,8 @@
+[
+  "string",
+  {
+    "title": ["string", null, null, "Name"]
+  },
+  null,
+  "Doe"
+]

--- a/formats/examples/element-meta-title.json
+++ b/formats/examples/element-meta-title.json
@@ -1,0 +1,10 @@
+{
+  "element": "string",
+  "meta": {
+    "title": {
+      "element": "string",
+      "content": "Name"
+    }
+  },
+  "content": "Doe"
+}

--- a/formats/examples/element.compact.json
+++ b/formats/examples/element.compact.json
@@ -1,0 +1,1 @@
+["string", null, null, "Hello World"]

--- a/formats/examples/element.json
+++ b/formats/examples/element.json
@@ -1,0 +1,4 @@
+{
+  "element": "string",
+  "content": "Hello World"
+}


### PR DESCRIPTION
This PR adds a collection of example cases of Refract serialisation. These example files can be used in a Refract libraries serialisation/deserialisation tests. A library can compare the serialised/deserialised results.

Each example is explained in the README.

These examples are also tested agains the schema for the JSON serialisation during CI.