### PR TITLE
Clarify compact serialisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,16 @@ language: python
 install: pip install jsonschema-test
 script:
   - jsonschema-test formats/json-refract-schema.json formats/json-refract-schema-tests.json
+  - jsonschema-test formats/json-compact-refract-schema.json formats/json-compact-refract-schema-tests.json
   - jsonschema formats/json-refract-schema.json -i formats/examples/element.json
   - jsonschema formats/json-refract-schema.json -i formats/examples/element-element.json
   - jsonschema formats/json-refract-schema.json -i formats/examples/element-array.json
   - jsonschema formats/json-refract-schema.json -i formats/examples/element-kv.json
   - jsonschema formats/json-refract-schema.json -i formats/examples/element-meta-title.json
   - jsonschema formats/json-refract-schema.json -i formats/examples/element-attributes.json
+  - jsonschema formats/json-compact-refract-schema.json -i formats/examples/element.compact.json
+  - jsonschema formats/json-compact-refract-schema.json -i formats/examples/element-element.compact.json
+  - jsonschema formats/json-compact-refract-schema.json -i formats/examples/element-array.compact.json
+  - jsonschema formats/json-compact-refract-schema.json -i formats/examples/element-kv.compact.json
+  - jsonschema formats/json-compact-refract-schema.json -i formats/examples/element-meta-title.compact.json
+  - jsonschema formats/json-compact-refract-schema.json -i formats/examples/element-attributes.compact.json

--- a/formats/json-compact-refract-schema-tests.json
+++ b/formats/json-compact-refract-schema-tests.json
@@ -1,0 +1,317 @@
+[
+  {
+    "description": "an element name",
+    "tests": [
+      {
+        "description": "with valid element name",
+        "data": ["string", null, null, null],
+        "valid": true
+      },
+      {
+        "description": "without an element name",
+        "data": [],
+        "valid": false
+      },
+      {
+        "description": "with an element name that is not a string",
+        "data": [null, null, null, null],
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "an element content",
+    "tests": [
+      {
+        "description": "without content",
+        "data": ["string", null, null],
+        "valid": false
+      },
+      {
+        "description": "with string content",
+        "data": ["string", null, null, "Hello World"],
+        "valid": true
+      },
+      {
+        "description": "with number content",
+        "data": ["number", null, null, 1],
+        "valid": true
+      },
+      {
+        "description": "with boolean content",
+        "data": ["boolean", null, null, true],
+        "valid": true
+      },
+      {
+        "description": "with null content",
+        "data": ["null", null, null, null],
+        "valid": true
+      },
+      {
+        "description": "with element content",
+        "data": ["custom", null, null, ["string", null, null, "Hello"]],
+        "valid": true
+      },
+      {
+        "description": "with array of element content",
+        "data": ["custom", null, null, [["string", null, null, "Hello"]]],
+        "valid": true
+      },
+      {
+        "description": "with key value pair element content",
+        "data": ["custom", null, null, [
+          "pair",
+          ["string", null, null, "key"],
+          ["string", null, null, "value"]
+        ]],
+        "valid": true
+      },
+      {
+        "description": "with array of non-element content",
+        "data": ["custom", null, null, ["hello"]],
+        "valid": false
+      },
+      {
+        "description": "with object as content",
+        "data": ["custom", null, null, {"something": "value"}],
+        "valid": false
+      },
+      {
+        "description": "with key value pair with additional properties element content",
+        "data": ["custom", null, null, ["pair",
+          ["string", null, null, ""],
+          ["string", null, null, ""],
+          ["additional", null, null, ""]
+        ]],
+        "valid": false
+      },
+      {
+        "description": "with key value pair without key element",
+        "data": ["custom", null, null, ["pair"]],
+        "valid": false
+      },
+      {
+        "description": "with key value pair with key that is not an element content",
+        "data": ["custom", null, null, ["pair",
+          "key",
+          ["string", null, null, ""]
+        ]],
+        "valid": false
+      },
+      {
+        "description": "with key value pair with value that is not an element content",
+        "data": ["custom", null, null, ["pair",
+          ["string", null, null, ""],
+          "value"
+        ]],
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "an element meta",
+    "tests": [
+      {
+        "description": "with non-object meta",
+        "data": ["string", [], null, null],
+        "valid": false
+      },
+      {
+        "description": "with id metadata",
+        "data": ["string", {"id": ["string", null, null, "Name"]}, null, null],
+        "valid": true
+      },
+      {
+        "description": "with non-element id metadata",
+        "data": ["string", {"id": "Name"}, null, null],
+        "valid": false
+      },
+      {
+        "description": "with title metadata",
+        "data": ["string", {"title": ["string", null, null, "Doe"]}, null, null],
+        "valid": true
+      },
+      {
+        "description": "with title metadata as non string element",
+        "data": ["string", {"title": ["number", null, null, 1]}, null, null],
+        "valid": false
+      },
+      {
+        "description": "with non-element title metadata",
+        "data": ["string", {"title": "Doe"}, null, null],
+        "valid": false
+      },
+      {
+        "description": "with description metadata",
+        "data": ["string", {"description": ["string", null, null, "Doe"]}, null, null],
+        "valid": true
+      },
+      {
+        "description": "with description metadata as non string element",
+        "data": ["string", {"description": ["number", null, null, 1]}, null, null],
+        "valid": false
+      },
+      {
+        "description": "with non-element description metadata",
+        "data": ["string", {"description": "test"}, null, null],
+        "valid": false
+      },
+      {
+        "description": "with unknown meta key",
+        "data": ["string", {"something": ["string", null, null, "test"]}, null, null],
+        "valid": false
+      },
+      {
+        "description": "with array element as classes",
+        "data": ["string", {
+          "classes": ["array", null, null, [
+            ["string", null, null, "test"]
+          ]]
+        }, null, null],
+        "valid": true
+      },
+      {
+        "description": "with array element of non string element as classes",
+        "data": ["string", {
+          "classes": ["array", null, null, [
+            ["number", null, null, 1]
+          ]]
+        }, null, null],
+        "valid": false
+      },
+      {
+        "description": "with non array element as classes",
+        "data": ["string", {"classes": ["string", null, null, "Doe"]}, null, null],
+        "valid": false
+      },
+      {
+        "description": "with an array as classes",
+        "data": ["string", {"classes": ["api"]}, null, null],
+        "valid": false
+      },
+      {
+        "description": "with array element as links",
+        "data": ["string", {
+          "links": ["array", null, null, [
+            ["link", null, null, null]
+          ]]
+        }, null, null],
+        "valid": true
+      },
+      {
+        "description": "with array element of non link element as links",
+        "data": ["string", {
+          "links": ["array", null, null, [
+            ["number", null, null, 2]
+          ]]
+        }, null, null],
+        "valid": false
+      },
+      {
+        "description": "with non array element as links",
+        "data": ["string", {
+          "links": ["string", null, null, "hi"]
+        }, null, null],
+        "valid": false
+      },
+      {
+        "description": "with element pointer as ref",
+        "data": ["string", {
+          "ref": ["elementPointer", null, null, "thing"]
+        }, null, null],
+        "valid": true
+      },
+      {
+        "description": "with element pointer with element path as ref",
+        "data": ["string", {
+          "ref": ["elementPointer", null, {
+            "path": ["string", null, null, "element"]
+          }, "thing"]
+        }, null, null],
+        "valid": true
+      },
+      {
+        "description": "with element pointer with meta path as ref",
+        "data": ["string", {
+          "ref": ["elementPointer", null, {
+            "path": ["string", null, null, "meta"]
+          }, "thing"]
+        }, null, null],
+        "valid": true
+      },
+      {
+        "description": "with element pointer with attributes path as ref",
+        "data": ["string", {
+          "ref": ["elementPointer", null, {
+            "path": ["string", null, null, "attributes"]
+          }, "thing"]
+        }, null, null],
+        "valid": true
+      },
+      {
+        "description": "with element pointer with content path as ref",
+        "data": ["string", {
+          "ref": ["elementPointer", null, {
+            "path": ["string", null, null, "content"]
+          }, "thing"]
+        }, null, null],
+        "valid": true
+      },
+      {
+        "description": "with element pointer with invalid path as ref",
+        "data": ["string", {
+          "ref": ["elementPointer", null, {
+            "path": ["string", null, null, "unknown"]
+          }, "thing"]
+        }, null, null],
+        "valid": false
+      },
+      {
+        "description": "with element pointer without content as ref",
+        "data": ["string", {
+          "ref": ["elementPointer", null, null, null]
+        }, null, null],
+        "valid": false
+      },
+      {
+        "description": "with non element pointer as ref",
+        "data": ["string", {
+          "ref": ["string", null, null, "hello"]
+        }, null, null],
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "an element attributes",
+    "tests": [
+      {
+        "description": "with non-object attributes",
+        "data": ["string", null, "attrs", ""],
+        "valid": false
+      },
+      {
+        "description": "with attributes with element value",
+        "data": ["string", null, {
+          "name": ["string", null, null, "Doe"]
+        }, ""],
+        "valid": true
+      },
+      {
+        "description": "with attributes with non element value",
+        "data": ["string", null, {"name": "string"}, ""],
+        "valid": false
+      }
+    ]
+  },
+  {
+    "description": "an element",
+    "tests": [
+      {
+        "description": "with additional items",
+        "data": ["string", null, null, "hello", null],
+        "valid": false
+      }
+    ]
+  }
+]

--- a/formats/json-compact-refract-schema.json
+++ b/formats/json-compact-refract-schema.json
@@ -1,0 +1,160 @@
+{
+  "oneOf": [
+    { "$ref": "#/definitions/element" }
+  ],
+  "definitions": {
+    "element": {
+      "title": "Element",
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "items": [
+        {
+          "type": "string"
+        },
+        {
+          "type": ["null", "object"],
+          "properties": {
+            "id": { "$ref": "#/definitions/element" },
+            "title": { "$ref": "#/definitions/string-element" },
+            "description": { "$ref": "#/definitions/string-element" },
+            "ref": { "$ref": "#/definitions/element-pointer" },
+            "classes": { "$ref": "#/definitions/array-string-element" },
+            "links": { "$ref": "#/definitions/array-link-element" }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": ["null", "object"],
+          "patternProperties": {
+            "": { "$ref": "#/definitions/element" }
+          }
+        },
+        {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "number" },
+            { "type": "boolean" },
+            { "type": "null" },
+            { "$ref": "#/definitions/element" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/definitions/element" }
+            },
+            { "$ref": "#/definitions/key-value-pair" }
+          ]
+        }
+      ]
+    },
+    "key-value-pair": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 3,
+      "items": [
+        { "enum": ["pair"] },
+        { "$ref": "#/definitions/element" },
+        { "$ref": "#/definitions/element" }
+      ]
+    },
+    "string-element": {
+      "title": "String Element",
+      "allOf": [
+        { "$ref": "#/definitions/element" },
+        {
+          "items": [
+            { "enum": ["string"] },
+            {},
+            {},
+            { "type": "string" }
+          ]
+        }
+      ]
+    },
+    "array-element": {
+      "title": "Array Element",
+      "allOf": [
+        { "$ref": "#/definitions/element" },
+        {
+          "items": [
+            { "enum": ["array"] },
+            {},
+            {},
+            { "type": "array" }
+          ]
+        }
+      ]
+    },
+    "array-string-element": {
+      "title": "Array Element of String Element",
+      "allOf": [
+        { "$ref": "#/definitions/array-element" },
+        {
+          "items": [
+            {},
+            {},
+            {},
+            { "items": { "$ref": "#/definitions/string-element" } }
+          ]
+        }
+      ]
+    },
+    "link-element": {
+      "title": "Link Element",
+      "allOf": [
+        { "$ref": "#/definitions/element" },
+        {
+          "items": [
+            { "enum": ["link"] },
+            {},
+            {},
+            {}
+          ]
+        }
+      ]
+    },
+    "array-link-element": {
+      "title": "Array Element of Link Element",
+      "allOf": [
+        { "$ref": "#/definitions/array-element" },
+        {
+          "items": [
+            {},
+            {},
+            {},
+            { "items": { "$ref": "#/definitions/link-element" } }
+          ]
+        }
+      ]
+    },
+    "element-pointer": {
+      "title": "Element Pointer",
+      "allOf": [
+        { "$ref": "#/definitions/element" },
+        {
+          "items": [
+            { "enum": ["elementPointer"] },
+            {},
+            {
+              "properties": {
+                "path": {
+                  "allOf": [
+                    { "$ref": "#/definitions/string-element" },
+                    {
+                      "items": [
+                        {},
+                        {},
+                        {},
+                        { "enum": ["element", "meta", "attributes", "content"] }
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            { "type": "string" }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/formats/json-compact-refract.md
+++ b/formats/json-compact-refract.md
@@ -6,67 +6,69 @@ serialization of Refract, as seen in the Refract specification. It also allows
 for expressing structures in a tuple, which resembles other formats like XML or
 Lisp.
 
-## Dependencies
+## Element (array)
 
-- [Refract Base
-Specification](https://github.com/refractproject/refract-spec/blob/master/refract-spec.md)
-
-## Data Structures
-
-### Compact Element (array)
-
-The Compact Element is a tuple where each item has a specific meaning. The
+The Element is a tuple where each item has a specific meaning. The
 first item is the element name, the second is the meta attribute section, the
 third is the attribute section, and the fourth is the content section.
 
-The downside of this format is that there is no way to distinguish between a
-normal array and a Compact Element. Because of this, in situations where there
-is ambiguity, the array SHOULD be treated as a normal array and handled
-accordingly. Ambiguity arises when an array is found in areas such as
-`attributes` or `content` and requires out-of-band information how to handle
-the array.
-
-#### Members
+A Refract element MUST be serialised as the following data structure as a JSON
+array.
 
 - (string, required) - Name of the element
-- (object, required) - Meta attributes of the element instance.
-  - `id` - Unique Identifier, MUST be unique throughout the document
-  - `ref` (Element Pointer) - Pointer to referenced element or type
-  - `classes` (array[string]) - Array of classifications for given element
-  - `title` (string) - Human-readable title of element
-  - `description` (string) - Human-readable description of element
-  - `links` (array[Link Element]) - Meta links for a given element
-- (object, required) - Attributes of the element instance
+- (object, nullable, required) - Meta attributes of the element instance
+    - `id` - Unique Identifier, MUST be unique throughout the document
+    - `ref` (Ref Element) - Pointer to referenced element or type
+    - `classes` (array[String Element]) - Array of classifications for given element
+    - `title` (string) - Human-readable title of element
+    - `description` (string) - Human-readable description of element
+    - `links` (array[Link Element]) - Meta links for a given element
+- (object, nullable, required) - Attributes of the element instance
 - (enum, required) - Element content with any of the following types
-  - (null)
-  - (string)
-  - (number)
-  - (boolean)
-  - (array)
-  - (object)
-  - (Compact Element)
-  - (array[Compact Element])
+    - Element
+    - array[Element]
+    - string
+    - boolean
+    - number
+    - null
+    - Key Value Pair
+
+## Key Value Pair (array)
+
+A Key Value Pair MUST be serialised a JSON array with the following values:
+
+- (string, fixed): pair
+- (Element, required) - Key
+- (Element, optional) - Value
 
 ## Example
 
-In the base specification, serialization looks something like this for JSON:
+If I have a String Element with the value `Hello` it would be serialised in
+JSON Compact Refract as:
 
 ```json
-{
-  "element": "foo",
-  "content": "bar"
-}
-```
-
-In Compact Refract, this same example looks like this:
-
-```json
-["foo", {}, {}, "bar"]
+["string", null, null, "Hello"]
 ```
 
 In this example, meta attributes and attributes are both required, even if the
 objects are empty. This is because this format relies on the structure of the
 array in order to determine values.
+
+If I attach a title meta attribute, the example would then be serialised as
+follows:
+
+```json
+[
+  "string",
+  {
+    "title": ["string", null, null, "My Title"]
+  },
+  null,
+  "Hello"
+]
+```
+
+See the [examples directory](examples/) for further examples.
 
 ## Pros and Cons
 
@@ -74,8 +76,5 @@ The benefits as mentioned are that this is a more concise format. In some
 cases, it may even be easier to write, or convert from other formats such as
 XML or Lisp.
 
-One downside of this format is that there is no simple way to distinguish a
-normal array from a Compact Refract array. This makes it hard to embed Refract
-within normal data structures, requiring that either the entire structure be
-converted to Compact Refract, or that the user relies on domain-specific
-information.
+One downside of this format is that it is less self-explanatory and harder to
+understand as a human.


### PR DESCRIPTION
There were ambiguities in the compact serialisation as mentioned by the existing specification. This PR removes these ambiguities in the same way that the full serialisation format did. Removing the ability to place objects or non element arrays inside content.

This PR goes on to add a definition on how to serialise a Key Value Pair in compact as this was missing and it wasn't clear how to serialise the pairs. They should be serialised as the following:

```json
[
  "pair",
  ["string", null, null, "key"],
  ["string", null, null, "value"]
]
```

The PR also allows meta and attributes to be `null` or an `object` as I've seen improve performance when this value is null instead of an empty object.

I've build an implementation of the serialiser/deserialiser for the compact format at https://github.com/kylef/refract.py/pull/1 which can be used as reference.

---

The serialisation format contains a JSON Schema with tests.