### PR TITLE
feat: Made key value pair an object in compact refract

### DIFF
--- a/formats/examples/element-kv.compact.json
+++ b/formats/examples/element-kv.compact.json
@@ -2,9 +2,8 @@
   "member",
   null,
   null,
-  [
-    "pair",
-    ["string", null, null, "Name"],
-    ["string", null, null, "Doe"]
-  ]
+  {
+    "key": ["string", null, null, "Name"],
+    "value": ["string", null, null, "Doe"]
+  }
 ]

--- a/formats/json-compact-refract-schema-tests.json
+++ b/formats/json-compact-refract-schema-tests.json
@@ -59,11 +59,10 @@
       },
       {
         "description": "with key value pair element content",
-        "data": ["custom", null, null, [
-          "pair",
-          ["string", null, null, "key"],
-          ["string", null, null, "value"]
-        ]],
+        "data": ["custom", null, null, {
+          "key": ["string", null, null, "key"],
+          "value": ["string", null, null, "value"]
+        }],
         "valid": true
       },
       {
@@ -78,32 +77,32 @@
       },
       {
         "description": "with key value pair with additional properties element content",
-        "data": ["custom", null, null, ["pair",
-          ["string", null, null, ""],
-          ["string", null, null, ""],
-          ["additional", null, null, ""]
-        ]],
+        "data": ["custom", null, null, {
+          "key": ["string", null, null, ""],
+          "value": ["string", null, null, ""],
+          "add": ["additional", null, null, ""]
+        }],
         "valid": false
       },
       {
         "description": "with key value pair without key element",
-        "data": ["custom", null, null, ["pair"]],
+        "data": ["custom", null, null, {}],
         "valid": false
       },
       {
         "description": "with key value pair with key that is not an element content",
-        "data": ["custom", null, null, ["pair",
-          "key",
-          ["string", null, null, ""]
-        ]],
+        "data": ["custom", null, null, {
+          "key": "key",
+          "value": ["string", null, null, ""]
+        }],
         "valid": false
       },
       {
         "description": "with key value pair with value that is not an element content",
-        "data": ["custom", null, null, ["pair",
-          ["string", null, null, ""],
-          "value"
-        ]],
+        "data": ["custom", null, null, {
+          "key": ["string", null, null, ""],
+          "value": "value"
+        }],
         "valid": false
       }
     ]

--- a/formats/json-compact-refract-schema.json
+++ b/formats/json-compact-refract-schema.json
@@ -47,14 +47,18 @@
       ]
     },
     "key-value-pair": {
-      "type": "array",
-      "minItems": 2,
-      "maxItems": 3,
-      "items": [
-        { "enum": ["pair"] },
-        { "$ref": "#/definitions/element" },
-        { "$ref": "#/definitions/element" }
-      ]
+      "title": "Key Value Pair",
+      "type": "object",
+      "properties": {
+        "key": {
+          "$ref": "#/definitions/element"
+        },
+        "value": {
+          "$ref": "#/definitions/element"
+        }
+      },
+      "required": ["key"],
+      "additionalProperties": false
     },
     "string-element": {
       "title": "String Element",

--- a/formats/json-compact-refract.md
+++ b/formats/json-compact-refract.md
@@ -33,13 +33,12 @@ array.
     - null
     - Key Value Pair
 
-## Key Value Pair (array)
+## Key Value Pair (object)
 
-A Key Value Pair MUST be serialised a JSON array with the following values:
+A Key Value Pair MUST be serialised as a JSON object with the following properties:
 
-- (string, fixed): pair
-- (Element, required) - Key
-- (Element, optional) - Value
+- key: (Element, required) - Key
+- value: (Element, optional) - Value
 
 ## Example
 


### PR DESCRIPTION
Having the keyword `pair` would become really confusing for the users and will feel more complex. And since we are doing `{ "id": ["string", null, null, "a"] }` for the meta anyway, I don't see any issue doing `{ "key": [], "value": [] }` instead of the `pair` array.