### PR TITLE
Place href inside content in link element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the Refract project will be documented in this file.
   directly. See
   [RFC15](https://github.com/refractproject/rfcs/blob/master/text/0015-full-serialisation.md)
   for more information.
+- Link elements now place href inside element content.
 
 ## [0.6.0] - 2015-12-15
 

--- a/refract-spec.md
+++ b/refract-spec.md
@@ -412,8 +412,8 @@ Hyperlinking MAY be used to link to other resources, provide links to instructio
 
 - `element`: link (string, fixed)
 - `attributes`
-    - `relation` (string) - Link relation type as specified in [RFC 5988](https://tools.ietf.org/html/rfc5988).
-    - `href` (string) - The URI for the given link
+    - `relation` (String Element) - Link relation type as specified in [RFC 5988](https://tools.ietf.org/html/rfc5988).
+- content (string) - The URI for the given link
 
 ### Example
 
@@ -423,9 +423,12 @@ The following shows a link with the relation of `foo` and the URL of `/bar`.
 {
   "element": "link",
   "attributes": {
-    "relation": "foo",
-    "href": "/bar"
+    "relation": {
+      "element": "string",
+      "content": "foo"
+    }
   }
+  "content": "/bar"
 }
 ```
 
@@ -445,9 +448,12 @@ Below is an example of how a profile link is used as a meta link in Refract.
       {
         "element": "link",
         "attributes": {
-          "relation": "profile",
-          "href": "http://example.com/profiles/foo"
+          "relation": {
+            "element": "string",
+            "content": "profile"
+          }
         }
+        "content": "http://example.com/profiles/foo"
       }
     ]
   },


### PR DESCRIPTION
I think that a link is effectively the URI and therefore it makes logical sense that the content of the link element is the "link" (URI). The relation is an attribute of the link, the relation of the link. This also aligns with the `ref` element that behaves similarly where the location is the content.