### PR TITLE
Move namespaces to profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@ Refract is a recursive data structure for expressing complex structures, relatio
 
 ## Documents
 
-- [Full Specification](refract-spec.md)
-- [Data Structure Namespace](namespaces/data-structure-namespace.md)
-- [API Description Namespace](namespaces/api-description-namespace.md)
-- [Parse Result Namespace](namespaces/parse-result-namespace.md)
+- [Refract Specification](refract-spec.md)
 
 ## Version
 
@@ -19,6 +16,10 @@ Refract is a recursive data structure for expressing complex structures, relatio
 
 - [JSON Refract](formats/json-refract.md)
 - [JSON Compact Refract](formats/json-compact-refract.md)
+
+## Refract Profiles
+
+- [API Elements](https://apielements.org) - Web API Description Profile.
 
 ## Libraries
 

--- a/namespaces/api-description-namespace.md
+++ b/namespaces/api-description-namespace.md
@@ -1,3 +1,0 @@
-# API Description Namespace
-
-Deprecated. Please see [API Elements](https://github.com/apiaryio/api-elements) for API description elements.

--- a/namespaces/data-structure-namespace.md
+++ b/namespaces/data-structure-namespace.md
@@ -1,3 +1,0 @@
-# Data Structure Namespace
-
-Deprecated. Please see [API Elements](https://github.com/apiaryio/api-elements) for data structure elements.

--- a/namespaces/parse-result-namespace.md
+++ b/namespaces/parse-result-namespace.md
@@ -1,3 +1,0 @@
-# Parse Result Namespace
-
-Deprecated. Please see [API Elements](https://github.com/apiaryio/api-elements) for parse result elements.


### PR DESCRIPTION
Update links to API Elements and remove the older "deprecated" namespaces.

Closes #56